### PR TITLE
refactor: 탠져린 7주차 미션

### DIFF
--- a/dist/swagger.json
+++ b/dist/swagger.json
@@ -119,6 +119,767 @@
 				],
 				"type": "object",
 				"additionalProperties": false
+			},
+			"ShopResponse": {
+				"properties": {
+					"shop_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"owner_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"region_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"region_name": {
+						"type": "string"
+					},
+					"shop_name": {
+						"type": "string"
+					},
+					"shop_position": {
+						"type": "string"
+					},
+					"shop_explain": {
+						"type": "string",
+						"nullable": true
+					},
+					"shop_phone": {
+						"type": "string",
+						"nullable": true
+					},
+					"status": {
+						"type": "string",
+						"nullable": true
+					}
+				},
+				"required": [
+					"shop_id",
+					"owner_id",
+					"region_id",
+					"region_name",
+					"shop_name",
+					"shop_position",
+					"shop_explain",
+					"shop_phone",
+					"status"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ApiResponse_ShopResponse_": {
+				"properties": {
+					"resultType": {
+						"type": "string",
+						"enum": [
+							"SUCCESS"
+						],
+						"nullable": false
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					},
+					"data": {
+						"$ref": "#/components/schemas/ShopResponse"
+					}
+				},
+				"required": [
+					"resultType",
+					"error",
+					"data"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ShopCreateRequest": {
+				"properties": {
+					"owner_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"region_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"shop_name": {
+						"type": "string"
+					},
+					"shop_position": {
+						"type": "string"
+					},
+					"shop_explain": {
+						"type": "string"
+					},
+					"shop_phone": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"owner_id",
+					"region_id",
+					"shop_name",
+					"shop_position"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ReviewCreateResponse": {
+				"properties": {
+					"review_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"shop_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"user_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"nickname": {
+						"type": "string"
+					},
+					"rating": {
+						"type": "number",
+						"format": "double"
+					},
+					"body": {
+						"type": "string"
+					},
+					"image_urls": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					},
+					"created_date": {
+						"type": "string",
+						"format": "date-time"
+					}
+				},
+				"required": [
+					"review_id",
+					"shop_id",
+					"user_id",
+					"nickname",
+					"rating",
+					"body",
+					"image_urls",
+					"created_date"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ApiResponse_ReviewCreateResponse_": {
+				"properties": {
+					"resultType": {
+						"type": "string",
+						"enum": [
+							"SUCCESS"
+						],
+						"nullable": false
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					},
+					"data": {
+						"$ref": "#/components/schemas/ReviewCreateResponse"
+					}
+				},
+				"required": [
+					"resultType",
+					"error",
+					"data"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ReviewCreateRequest": {
+				"properties": {
+					"user_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"user_mission_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"rating": {
+						"type": "number",
+						"format": "double"
+					},
+					"body": {
+						"type": "string"
+					},
+					"image_urls": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"user_id",
+					"user_mission_id",
+					"rating",
+					"body"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ReviewsListResponse": {
+				"properties": {
+					"data": {
+						"items": {
+							"properties": {
+								"created_date": {
+									"type": "string",
+									"format": "date-time"
+								},
+								"body": {
+									"type": "string"
+								},
+								"rating": {
+									"type": "number",
+									"format": "double"
+								},
+								"nickname": {
+									"type": "string"
+								},
+								"review_id": {
+									"type": "number",
+									"format": "double"
+								}
+							},
+							"required": [
+								"created_date",
+								"body",
+								"rating",
+								"nickname",
+								"review_id"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"pagination": {
+						"properties": {
+							"cursor": {
+								"type": "number",
+								"format": "double",
+								"nullable": true
+							}
+						},
+						"required": [
+							"cursor"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"data",
+					"pagination"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ApiResponse_ReviewsListResponse_": {
+				"properties": {
+					"resultType": {
+						"type": "string",
+						"enum": [
+							"SUCCESS"
+						],
+						"nullable": false
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					},
+					"data": {
+						"$ref": "#/components/schemas/ReviewsListResponse"
+					}
+				},
+				"required": [
+					"resultType",
+					"error",
+					"data"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"MyReviewsListResponse": {
+				"properties": {
+					"data": {
+						"items": {
+							"properties": {
+								"created_date": {
+									"type": "string",
+									"format": "date-time"
+								},
+								"body": {
+									"type": "string"
+								},
+								"rating": {
+									"type": "number",
+									"format": "double"
+								},
+								"shop_name": {
+									"type": "string"
+								},
+								"shop_id": {
+									"type": "number",
+									"format": "double"
+								},
+								"review_id": {
+									"type": "number",
+									"format": "double"
+								}
+							},
+							"required": [
+								"created_date",
+								"body",
+								"rating",
+								"shop_name",
+								"shop_id",
+								"review_id"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"pagination": {
+						"properties": {
+							"cursor": {
+								"type": "number",
+								"format": "double",
+								"nullable": true
+							}
+						},
+						"required": [
+							"cursor"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"data",
+					"pagination"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ApiResponse_MyReviewsListResponse_": {
+				"properties": {
+					"resultType": {
+						"type": "string",
+						"enum": [
+							"SUCCESS"
+						],
+						"nullable": false
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					},
+					"data": {
+						"$ref": "#/components/schemas/MyReviewsListResponse"
+					}
+				},
+				"required": [
+					"resultType",
+					"error",
+					"data"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"MissionResponse": {
+				"properties": {
+					"mission_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"shop_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"title": {
+						"type": "string"
+					},
+					"body": {
+						"type": "string"
+					},
+					"point": {
+						"type": "number",
+						"format": "double"
+					},
+					"status": {
+						"type": "string",
+						"nullable": true
+					},
+					"created_date": {
+						"type": "string",
+						"format": "date-time",
+						"nullable": true
+					}
+				},
+				"required": [
+					"mission_id",
+					"shop_id",
+					"title",
+					"body",
+					"point",
+					"status",
+					"created_date"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ApiResponse_MissionResponse_": {
+				"properties": {
+					"resultType": {
+						"type": "string",
+						"enum": [
+							"SUCCESS"
+						],
+						"nullable": false
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					},
+					"data": {
+						"$ref": "#/components/schemas/MissionResponse"
+					}
+				},
+				"required": [
+					"resultType",
+					"error",
+					"data"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"MissionCreateRequest": {
+				"properties": {
+					"shop_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"title": {
+						"type": "string"
+					},
+					"body": {
+						"type": "string"
+					},
+					"point": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"shop_id",
+					"title",
+					"body",
+					"point"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"MissionsListResponse": {
+				"properties": {
+					"data": {
+						"items": {
+							"properties": {
+								"created_date": {
+									"type": "string",
+									"format": "date-time",
+									"nullable": true
+								},
+								"status": {
+									"type": "string",
+									"nullable": true
+								},
+								"point": {
+									"type": "number",
+									"format": "double"
+								},
+								"body": {
+									"type": "string"
+								},
+								"title": {
+									"type": "string"
+								},
+								"shop_id": {
+									"type": "number",
+									"format": "double"
+								},
+								"mission_id": {
+									"type": "number",
+									"format": "double"
+								}
+							},
+							"required": [
+								"created_date",
+								"status",
+								"point",
+								"body",
+								"title",
+								"shop_id",
+								"mission_id"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"pagination": {
+						"properties": {
+							"cursor": {
+								"type": "number",
+								"format": "double",
+								"nullable": true
+							}
+						},
+						"required": [
+							"cursor"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"data",
+					"pagination"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ApiResponse_MissionsListResponse_": {
+				"properties": {
+					"resultType": {
+						"type": "string",
+						"enum": [
+							"SUCCESS"
+						],
+						"nullable": false
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					},
+					"data": {
+						"$ref": "#/components/schemas/MissionsListResponse"
+					}
+				},
+				"required": [
+					"resultType",
+					"error",
+					"data"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"UserMissionResponse": {
+				"properties": {
+					"user_mission_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"user_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"mission_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"status": {
+						"type": "string"
+					},
+					"created_date": {
+						"type": "string",
+						"format": "date-time",
+						"nullable": true
+					}
+				},
+				"required": [
+					"user_mission_id",
+					"user_id",
+					"mission_id",
+					"status",
+					"created_date"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ApiResponse_UserMissionResponse_": {
+				"properties": {
+					"resultType": {
+						"type": "string",
+						"enum": [
+							"SUCCESS"
+						],
+						"nullable": false
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					},
+					"data": {
+						"$ref": "#/components/schemas/UserMissionResponse"
+					}
+				},
+				"required": [
+					"resultType",
+					"error",
+					"data"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"UserMissionCreateRequest": {
+				"properties": {
+					"user_id": {
+						"type": "number",
+						"format": "double"
+					},
+					"mission_id": {
+						"type": "number",
+						"format": "double"
+					}
+				},
+				"required": [
+					"user_id",
+					"mission_id"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"InProgressMissionsListResponse": {
+				"properties": {
+					"data": {
+						"items": {
+							"properties": {
+								"created_date": {
+									"type": "string",
+									"format": "date-time",
+									"nullable": true
+								},
+								"status": {
+									"type": "string"
+								},
+								"point": {
+									"type": "number",
+									"format": "double"
+								},
+								"body": {
+									"type": "string"
+								},
+								"title": {
+									"type": "string"
+								},
+								"shop_id": {
+									"type": "number",
+									"format": "double"
+								},
+								"mission_id": {
+									"type": "number",
+									"format": "double"
+								},
+								"user_mission_id": {
+									"type": "number",
+									"format": "double"
+								}
+							},
+							"required": [
+								"created_date",
+								"status",
+								"point",
+								"body",
+								"title",
+								"shop_id",
+								"mission_id",
+								"user_mission_id"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					},
+					"pagination": {
+						"properties": {
+							"cursor": {
+								"type": "number",
+								"format": "double",
+								"nullable": true
+							}
+						},
+						"required": [
+							"cursor"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"data",
+					"pagination"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ApiResponse_InProgressMissionsListResponse_": {
+				"properties": {
+					"resultType": {
+						"type": "string",
+						"enum": [
+							"SUCCESS"
+						],
+						"nullable": false
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					},
+					"data": {
+						"$ref": "#/components/schemas/InProgressMissionsListResponse"
+					}
+				},
+				"required": [
+					"resultType",
+					"error",
+					"data"
+				],
+				"type": "object",
+				"additionalProperties": false
 			}
 		},
 		"securitySchemes": {}
@@ -273,6 +1034,369 @@
 				],
 				"security": [],
 				"parameters": []
+			}
+		},
+		"/regions/{regionId}/shops": {
+			"post": {
+				"operationId": "HandleCreateShop",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiResponse_ShopResponse_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Shops"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "regionId",
+						"required": true,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/ShopCreateRequest"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/shops/{shopId}/reviews": {
+			"post": {
+				"operationId": "HandleCreateReview",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiResponse_ReviewCreateResponse_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Reviews"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "shopId",
+						"required": true,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/ReviewCreateRequest"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "HandleGetReviews",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiResponse_ReviewsListResponse_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Reviews"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "shopId",
+						"required": true,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					},
+					{
+						"in": "query",
+						"name": "cursor",
+						"required": false,
+						"schema": {
+							"default": 0,
+							"format": "double",
+							"type": "number"
+						}
+					}
+				]
+			}
+		},
+		"/users/{userId}/reviews": {
+			"get": {
+				"operationId": "HandleGetMyReviews",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiResponse_MyReviewsListResponse_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Reviews"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "userId",
+						"required": true,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					},
+					{
+						"in": "query",
+						"name": "cursor",
+						"required": false,
+						"schema": {
+							"default": 0,
+							"format": "double",
+							"type": "number"
+						}
+					}
+				]
+			}
+		},
+		"/shops/{shopId}/missions": {
+			"post": {
+				"operationId": "HandleCreateMission",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiResponse_MissionResponse_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Missions"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "shopId",
+						"required": true,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					}
+				],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/MissionCreateRequest"
+							}
+						}
+					}
+				}
+			},
+			"get": {
+				"operationId": "HandleGetMissions",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiResponse_MissionsListResponse_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Missions"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "shopId",
+						"required": true,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					},
+					{
+						"in": "query",
+						"name": "cursor",
+						"required": false,
+						"schema": {
+							"default": 0,
+							"format": "double",
+							"type": "number"
+						}
+					}
+				]
+			}
+		},
+		"/missions/challenge": {
+			"post": {
+				"operationId": "HandleChallengeMission",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiResponse_UserMissionResponse_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Missions"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UserMissionCreateRequest"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/users/{userId}/missions/in-progress": {
+			"get": {
+				"operationId": "HandleGetInProgressMissions",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiResponse_InProgressMissionsListResponse_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Missions"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "userId",
+						"required": true,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					},
+					{
+						"in": "query",
+						"name": "cursor",
+						"required": false,
+						"schema": {
+							"default": 0,
+							"format": "double",
+							"type": "number"
+						}
+					}
+				]
+			}
+		},
+		"/users/{userId}/missions/{userMissionId}/complete": {
+			"patch": {
+				"operationId": "HandleCompleteInProgressMission",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiResponse_UserMissionResponse_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Missions"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "userId",
+						"required": true,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					},
+					{
+						"in": "path",
+						"name": "userMissionId",
+						"required": true,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					}
+				]
 			}
 		}
 	},

--- a/dist/swagger.json
+++ b/dist/swagger.json
@@ -1,0 +1,284 @@
+{
+	"openapi": "3.0.0",
+	"components": {
+		"examples": {},
+		"headers": {},
+		"parameters": {},
+		"requestBodies": {},
+		"responses": {},
+		"schemas": {
+			"UserSignUpResponse": {
+				"properties": {
+					"userId": {
+						"type": "number",
+						"format": "double"
+					},
+					"preferences": {
+						"items": {
+							"type": "string"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"userId",
+					"preferences"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ApiResponse_UserSignUpResponse_": {
+				"properties": {
+					"resultType": {
+						"type": "string",
+						"enum": [
+							"SUCCESS"
+						],
+						"nullable": false
+					},
+					"error": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					},
+					"data": {
+						"$ref": "#/components/schemas/UserSignUpResponse"
+					}
+				},
+				"required": [
+					"resultType",
+					"error",
+					"data"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"UserSignUpRequest": {
+				"properties": {
+					"user_name": {
+						"type": "string"
+					},
+					"nickname": {
+						"type": "string"
+					},
+					"user_phone": {
+						"type": "string"
+					},
+					"user_gender": {
+						"type": "string",
+						"enum": [
+							"여성",
+							"남성"
+						]
+					},
+					"birth_data": {
+						"type": "string"
+					},
+					"address": {
+						"type": "string"
+					},
+					"role": {
+						"type": "string",
+						"enum": [
+							"일반 사용자",
+							"가게 운영자"
+						]
+					},
+					"point": {
+						"type": "number",
+						"format": "double"
+					},
+					"email": {
+						"type": "string"
+					},
+					"preferences": {
+						"items": {
+							"type": "number",
+							"format": "double"
+						},
+						"type": "array"
+					},
+					"password": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"user_name",
+					"nickname",
+					"user_phone",
+					"user_gender",
+					"birth_data",
+					"address",
+					"role",
+					"point",
+					"email",
+					"preferences",
+					"password"
+				],
+				"type": "object",
+				"additionalProperties": false
+			}
+		},
+		"securitySchemes": {}
+	},
+	"info": {
+		"title": "playground-umc-7th-nodejs",
+		"version": "1.0.0",
+		"description": "UMC 테스트 프로젝트",
+		"license": {
+			"name": "ISC"
+		},
+		"contact": {}
+	},
+	"paths": {
+		"/users/signup": {
+			"post": {
+				"operationId": "HandleUserSignUp",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiResponse_UserSignUpResponse_"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Users"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UserSignUpRequest"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/users/guest": {
+			"get": {
+				"operationId": "HandleGuestPage",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Users"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/users/login": {
+			"get": {
+				"operationId": "HandleLoginPage",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Users"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/users/mypage": {
+			"get": {
+				"operationId": "HandleMypage",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Users"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/users/set-login": {
+			"get": {
+				"operationId": "HandleSetLogin",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Users"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/users/set-logout": {
+			"get": {
+				"operationId": "HandleSetLogout",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				},
+				"tags": [
+					"Users"
+				],
+				"security": [],
+				"parameters": []
+			}
+		}
+	},
+	"servers": [
+		{
+			"url": "/"
+		}
+	]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,19 @@
       "dependencies": {
         "@prisma/adapter-mariadb": "^7.8.0",
         "@prisma/client": "^7.8.0",
+        "@types/morgan": "^1.9.10",
         "bcrypt": "^6.0.0",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
-        "http-status-codes": "^2.3.0"
+        "http-status-codes": "^2.3.0",
+        "morgan": "^1.10.1",
+        "tsoa": "^7.0.0-alpha.0"
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
+        "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "nodemon": "^3.1.4",
@@ -499,6 +504,322 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hapi/accept": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-6.0.3.tgz",
+      "integrity": "sha512-p72f9k56EuF0n3MwlBNThyVE5PXX40g+aQh+C/xbKrfzahM2Oispv3AXmOIU51t3j77zay1qrX7IIziZXspMlw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/ammo": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.1.tgz",
+      "integrity": "sha512-pmL+nPod4g58kXrMcsGLp05O2jF4P2Q3GiL8qYV7nKYEh3cGf+rV4P5Jyi2Uq0agGhVU63GtaSAfBEZOlrJn9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/b64": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.1.tgz",
+      "integrity": "sha512-ZvjX4JQReUmBheeCq+S9YavcnMMHWqx3S0jHNXWIM1kQDxB9cyfSycpVvjfrKcIS8Mh5N3hmu/YKo4Iag9g2Kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/boom": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.1.tgz",
+      "integrity": "sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/bounce": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.2.tgz",
+      "integrity": "sha512-d0XmlTi3H9HFDHhQLjg4F4auL1EY3Wqj7j7/hGDhFFe6xAbnm3qiGrXeT93zZnPH8gH+SKAFYiRzu26xkXcH3g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/bourne": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/call": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-9.0.1.tgz",
+      "integrity": "sha512-uPojQRqEL1GRZR4xXPqcLMujQGaEpyVPRyBlD8Pp5rqgIwLhtveF9PkixiKru2THXvuN8mUrLeet5fqxKAAMGg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/catbox": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-12.1.1.tgz",
+      "integrity": "sha512-hDqYB1J+R0HtZg4iPH3LEnldoaBsar6bYp0EonBmNQ9t5CO+1CqgCul2ZtFveW1ReA5SQuze9GPSU7/aecERhw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/podium": "^5.0.0",
+        "@hapi/validate": "^2.0.1"
+      }
+    },
+    "node_modules/@hapi/catbox-memory": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.2.tgz",
+      "integrity": "sha512-H1l4ugoFW/ZRkqeFrIo8p1rWN0PA4MDTfu4JmcoNDvnY975o29mqoZblqFTotxNHlEkMPpIiIBJTV+Mbi+aF0g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/content": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.2.tgz",
+      "integrity": "sha512-OKyCOTjNR1hftwSjk9ueyAQTw8AwapvzBrPIWMGn39vhR5PmqLdYFmLc35bsSBye7gSMnlkXfc679bUdMIcRyQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.0"
+      }
+    },
+    "node_modules/@hapi/cryptiles": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.3.tgz",
+      "integrity": "sha512-r6VKalpbMHz4ci3gFjFysBmhwCg70RpYZy6OkjEpdXzAYnYFX5XsW7n4YMJvuIYpnMwLxGUjK/cBhA7X3JDvXw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/file": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
+      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hapi": {
+      "version": "21.4.9",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.4.9.tgz",
+      "integrity": "sha512-YnecZOVx2AD08VvPl0ZaFS0MjEHqg+InGRmBRli731ct+VwI++dpu3BIYA1Z4SMr6HUAnpyvbQ1aq5woe3fBWg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/accept": "^6.0.3",
+        "@hapi/ammo": "^6.0.1",
+        "@hapi/boom": "^10.0.1",
+        "@hapi/bounce": "^3.0.2",
+        "@hapi/call": "^9.0.1",
+        "@hapi/catbox": "^12.1.1",
+        "@hapi/catbox-memory": "^6.0.2",
+        "@hapi/heavy": "^8.0.1",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/mimos": "^7.0.1",
+        "@hapi/podium": "^5.0.2",
+        "@hapi/shot": "^6.0.2",
+        "@hapi/somever": "^4.1.1",
+        "@hapi/statehood": "^8.2.1",
+        "@hapi/subtext": "^8.1.3",
+        "@hapi/teamwork": "^6.0.1",
+        "@hapi/topo": "^6.0.2",
+        "@hapi/validate": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      }
+    },
+    "node_modules/@hapi/heavy": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-8.0.1.tgz",
+      "integrity": "sha512-gBD/NANosNCOp6RsYTsjo2vhr5eYA3BEuogk6cxY0QdhllkkTaJFYtTXv46xd6qhBVMbMMqcSdtqey+UQU3//w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/validate": "^2.0.1"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/iron": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-7.0.1.tgz",
+      "integrity": "sha512-tEZnrOujKpS6jLKliyWBl3A9PaE+ppuL/+gkbyPPDb/l2KSKQyH4lhMkVb+sBhwN+qaxxlig01JRqB8dk/mPxQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/b64": "^6.0.1",
+        "@hapi/boom": "^10.0.1",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/mimos": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-7.0.1.tgz",
+      "integrity": "sha512-b79V+BrG0gJ9zcRx1VGcCI6r6GEzzZUgiGEJVoq5gwzuB2Ig9Cax8dUuBauQCFKvl2YWSWyOc8mZ8HDaJOtkew==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2",
+        "mime-db": "^1.52.0"
+      }
+    },
+    "node_modules/@hapi/nigel": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.1.tgz",
+      "integrity": "sha512-uv3dtYuB4IsNaha+tigWmN8mQw/O9Qzl5U26Gm4ZcJVtDdB1AVJOwX3X5wOX+A07qzpEZnOMBAm8jjSqGsU6Nw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/vise": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/pez": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.1.1.tgz",
+      "integrity": "sha512-yg2OS1tC0S1sHXvhUtWsfRn6lrKl9jKtRhZ+EI0woOW/gqX5vM2PZ1459ypCvCYDRLJ9nIyueeEH5MJV1ZDqIg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/b64": "^6.0.1",
+        "@hapi/boom": "^10.0.1",
+        "@hapi/content": "^6.0.1",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/nigel": "^5.0.1"
+      }
+    },
+    "node_modules/@hapi/podium": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.2.tgz",
+      "integrity": "sha512-T7gf2JYHQQfEfewTQFbsaXoZxSvuXO/QBIGljucUQ/lmPnTTNAepoIKOakWNVWvo2fMEDjycu77r8k6dhreqHA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/validate": "^2.0.1"
+      }
+    },
+    "node_modules/@hapi/shot": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-6.0.2.tgz",
+      "integrity": "sha512-WKK1ShfJTrL1oXC0skoIZQYzvLsyMDEF8lfcWuQBjpjCN29qivr9U36ld1z0nt6edvzv28etNMOqUF4klnHryw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/validate": "^2.0.1"
+      }
+    },
+    "node_modules/@hapi/somever": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.1.tgz",
+      "integrity": "sha512-lt3QQiDDOVRatS0ionFDNrDIv4eXz58IibQaZQDOg4DqqdNme8oa0iPWcE0+hkq/KTeBCPtEOjDOBKBKwDumVg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/bounce": "^3.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/statehood": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-8.2.1.tgz",
+      "integrity": "sha512-xf72TG/QINW26jUu+uL5H+crE1o8GplIgfPWwPZhnAGJzetIVAQEQYvzq+C0aEVHg5/lMMtQ+L9UryuSa5Yjkg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/bounce": "^3.0.1",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.1",
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/iron": "^7.0.1",
+        "@hapi/validate": "^2.0.1"
+      }
+    },
+    "node_modules/@hapi/subtext": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.1.3.tgz",
+      "integrity": "sha512-WTpEZQjBP3UJ3gGunNl3w5Ao1EOJsuu2vttZ2KEcG+csSLxc0dI6VIkl2md2jDlHiQ2ARAoqdSUScy05A/NHtA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/content": "^6.0.2",
+        "@hapi/file": "^3.0.0",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pez": "^6.1.1",
+        "@hapi/wreck": "^18.1.1"
+      }
+    },
+    "node_modules/@hapi/teamwork": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.1.tgz",
+      "integrity": "sha512-52OXRslUfYwXAOG8k58f2h2ngXYQGP0x5RPOo+eWA/FtyLgHjGMrE3+e9LSXP/0q2YfHAK5wj9aA9DTy1K+kyQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/validate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.1.tgz",
+      "integrity": "sha512-NZmXRnrSLK8MQ9y/CMqE9WSspgB9xA41/LlYR0k967aSZebWr4yNrpxIbov12ICwKy4APSlWXZga9jN5p6puPA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/topo": "^6.0.1"
+      }
+    },
+    "node_modules/@hapi/vise": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-5.0.1.tgz",
+      "integrity": "sha512-XZYWzzRtINQLedPYlIkSkUr7m5Ddwlu99V9elh8CSygXstfv3UnWIXT0QD+wmR0VAG34d2Vx3olqcEhRRoTu9A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/wreck": {
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.1.tgz",
+      "integrity": "sha512-UwTeGBfAnB/1mkw4gD6IQGI/bgMu7iGmqgT8K+xxye3z4ZHhCZlmS2wuHBJmENhBJSKqvoYzJ71ds3Xfq4gofQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.11",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
@@ -512,12 +833,39 @@
         "hono": "^4"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@kurkle/color": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@prisma/adapter-mariadb": {
       "version": "7.8.0",
@@ -881,6 +1229,395 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@tsoa/cli": {
+      "version": "7.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@tsoa/cli/-/cli-7.0.0-alpha.0.tgz",
+      "integrity": "sha512-fCBWv6F20qrpwFh5X+vaZs38Bh/5cVwKPhvG/uArR+crZgEowyNl76unLCmYdvycES9Y6g/TKFLagG8qojSNuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsoa/runtime": "^7.0.0-alpha.0",
+        "@types/multer": "^1.4.12",
+        "fs-extra": "^11.2.0",
+        "glob": "^10.3.10",
+        "handlebars": "^4.7.8",
+        "merge-anything": "^5.1.7",
+        "minimatch": "^9.0.1",
+        "ts-deepmerge": "^7.0.2",
+        "typescript": "^5.7.2",
+        "validator": "^13.12.0",
+        "yaml": "^2.6.1",
+        "yargs": "^17.7.1"
+      },
+      "bin": {
+        "tsoa": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "yarn": ">=1.9.4"
+      }
+    },
+    "node_modules/@tsoa/cli/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/@tsoa/cli/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@tsoa/cli/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@tsoa/cli/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@tsoa/runtime": {
+      "version": "7.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@tsoa/runtime/-/runtime-7.0.0-alpha.0.tgz",
+      "integrity": "sha512-zlWYz2bLfaN6WtFoIbLBEAyVhKG4IQKJ9QPzeRFFKeAsh5zYN4/ocnd14XyWs4ehY9TdtTnma2drW89aYNSRYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hapi": "^21.3.12",
+        "@types/koa": "^2.15.0",
+        "@types/multer": "^1.4.12",
+        "express": "^4.21.2",
+        "reflect-metadata": "^0.2.2",
+        "validator": "^13.12.0"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "yarn": ">=1.9.4"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/@tsoa/runtime/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/@tsoa/runtime/node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/express/node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/@tsoa/runtime/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@tsoa/runtime/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@types/accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/bcrypt": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
@@ -895,7 +1632,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -906,9 +1642,36 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/content-disposition": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.9.tgz",
+      "integrity": "sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/cookies": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.2.tgz",
+      "integrity": "sha512-1AvkDdZM2dbyFybL4fxpuNCaWyv//0AwsuUk2DWeXyM1/5ZKm6W3z6mQi24RZ4l2ucY+bkSHzbDVpySqPGuV8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
         "@types/node": "*"
       }
     },
@@ -926,7 +1689,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -938,7 +1700,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -953,18 +1714,71 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
+    "node_modules/@types/http-assert": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.6.tgz",
+      "integrity": "sha512-TTEwmtjgVbYAzZYWyeHPrrtWnfVkm8tQkP8P21uQifPgMRgjrow3XDEYqucuC8SKZJT7pUnhU/JymvjggxO9vw==",
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/keygrip": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
+      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/koa": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.0.tgz",
+      "integrity": "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/accepts": "*",
+        "@types/content-disposition": "*",
+        "@types/cookies": "*",
+        "@types/http-assert": "*",
+        "@types/http-errors": "*",
+        "@types/keygrip": "*",
+        "@types/koa-compose": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/koa-compose": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.9.tgz",
+      "integrity": "sha512-BroAZ9FTvPiCy0Pi8tjD1OfJ7bgU1gQf0eR6e1Vm+JJATy9eKOG3hQMFtMciMawiSOVnLMdmUOC46s7HBhSTsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/koa": "*"
+      }
+    },
+    "node_modules/@types/morgan": {
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.10.tgz",
+      "integrity": "sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/multer": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.13.tgz",
+      "integrity": "sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -974,14 +1788,12 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -999,7 +1811,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1009,7 +1820,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -1046,6 +1856,30 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -1059,6 +1893,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
     },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
@@ -1079,6 +1919,24 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/bcrypt": {
       "version": "6.0.0",
@@ -1299,6 +2157,111 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/confbox": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
@@ -1337,6 +2300,25 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
@@ -1367,7 +2349,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1445,6 +2426,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
@@ -1471,6 +2462,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1487,6 +2484,12 @@
         "@standard-schema/spec": "^1.0.0",
         "fast-check": "^3.23.1"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
     },
     "node_modules/empathic": {
       "version": "2.0.0",
@@ -1590,6 +2593,15 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -1742,7 +2754,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -1771,6 +2782,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/fsevents": {
@@ -1805,6 +2830,15 @@
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1874,6 +2908,27 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -1885,6 +2940,36 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {
@@ -1903,7 +2988,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/grammex": {
@@ -1919,6 +3003,27 @@
       "integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -2051,6 +3156,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2087,12 +3201,38 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -2110,6 +3250,18 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -2201,6 +3353,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/merge-anything": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-5.1.7.tgz",
+      "integrity": "sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
@@ -2211,6 +3378,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
@@ -2254,6 +3442,67 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/morgan": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/morgan/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2281,6 +3530,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
     },
     "node_modules/node-addon-api": {
       "version": "8.7.0",
@@ -2381,6 +3636,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2389,6 +3653,12 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -2403,10 +3673,25 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2671,6 +3956,12 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/remeda": {
       "version": "2.33.4",
       "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
@@ -2679,6 +3970,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/remeda"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -2726,6 +4026,26 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -2815,7 +4135,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -2828,7 +4147,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2910,7 +4228,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -2930,6 +4247,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sqlstring": {
@@ -2957,6 +4283,102 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -3001,6 +4423,32 @@
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/ts-deepmerge": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.3.tgz",
+      "integrity": "sha512-Du/ZW2RfwV/D4cmA5rXafYjBQVuvu4qGiEEla4EmEHVHgRdx68Gftx7i66jn2bzHPwSVZY36Ae6OuDn9el4ZKA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14.13.1"
+      }
+    },
+    "node_modules/tsoa": {
+      "version": "7.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/tsoa/-/tsoa-7.0.0-alpha.0.tgz",
+      "integrity": "sha512-o5h2DD1IKa2GF728BHYDL2uSX57a44sX8BLFScR4KbD0xlOmgsSDECneJmouDxf9MJdjHHWc+I1S3sGK82B6kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsoa/cli": "^7.0.0-alpha.0",
+        "@tsoa/runtime": "^7.0.0-alpha.0"
+      },
+      "bin": {
+        "tsoa": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "yarn": ">=1.9.4"
       }
     },
     "node_modules/tsx": {
@@ -3051,6 +4499,19 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -3062,8 +4523,16 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -3072,6 +4541,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/valibot": {
@@ -3089,6 +4567,15 @@
         }
       }
     },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -3102,7 +4589,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -3114,11 +4600,200 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/zeptomatch": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -6,22 +6,27 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "npx prisma generate && tsc && node dist/index.js",
-    "dev": "nodemon --ext ts,prisma --exec \"npx prisma generate && tsx src/index.ts\""
+    "start": "tsoa spec-and-routes && tsx src/index.ts",
+    "dev": "tsoa spec-and-routes && nodemon --exec tsx src/index.ts"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "@prisma/adapter-mariadb": "^7.8.0",
     "@prisma/client": "^7.8.0",
+    "@types/morgan": "^1.9.10",
     "bcrypt": "^6.0.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
-    "http-status-codes": "^2.3.0"
+    "http-status-codes": "^2.3.0",
+    "morgan": "^1.10.1",
+    "tsoa": "^7.0.0-alpha.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
+    "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "nodemon": "^3.1.4",

--- a/src/common/errors/app.error.ts
+++ b/src/common/errors/app.error.ts
@@ -1,0 +1,18 @@
+export class AppError extends Error {
+    public readonly errorCode: string;
+    public readonly statusCode: number;
+    public readonly data?: any;
+  
+    constructor(params?: {
+      errorCode: string;
+      message: string;
+      statusCode: number;
+      data?: any;
+    }) {
+      super(params?.message);
+      this.errorCode = params?.errorCode ?? "UNKNOWN";
+      this.statusCode = params?.statusCode ?? 500;
+      this.data = params?.data ?? null;
+    }
+  }
+  

--- a/src/common/errors/error.ts
+++ b/src/common/errors/error.ts
@@ -1,0 +1,12 @@
+import { AppError } from "./app.error.js";
+
+export class DuplicateUserEmailError extends AppError {
+  constructor(message: string, data?: unknown) {
+    super({
+      errorCode: "U001",
+      statusCode: 409,
+      message,
+      data,
+    });
+  }
+}

--- a/src/common/errors/error.ts
+++ b/src/common/errors/error.ts
@@ -10,3 +10,47 @@ export class DuplicateUserEmailError extends AppError {
     });
   }
 }
+
+export class NotFoundError extends AppError {
+  constructor(message: string, data?: unknown) {
+    super({
+      errorCode: "COMMON404",
+      statusCode: 404,
+      message,
+      data,
+    });
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(message: string, data?: unknown) {
+    super({
+      errorCode: "COMMON400",
+      statusCode: 400,
+      message,
+      data,
+    });
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message: string, data?: unknown) {
+    super({
+      errorCode: "COMMON409",
+      statusCode: 409,
+      message,
+      data,
+    });
+  }
+}
+
+export class InternalServerError extends AppError {
+  constructor(message: string, data?: unknown) {
+    super({
+      errorCode: "COMMON500",
+      statusCode: 500,
+      message,
+      data,
+    });
+  }
+}

--- a/src/common/middlewares/auth.middleware.ts
+++ b/src/common/middlewares/auth.middleware.ts
@@ -1,0 +1,18 @@
+import { Request, Response, NextFunction } from "express";
+export function authorizeUser() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+	  // cookie-parser가 만들어준 req.cookies 객체에서 username을 확인
+    const { username } = req.cookies;
+    if (username) {
+      console.log(`[인증 성공] ${username}님, 환영합니다.`);
+      next();
+    } else {
+      console.log("[인증 실패] 로그인이 필요합니다.");
+      res
+        .status(401)
+        .send(
+          '<script>alert("로그인이 필요합니다!");location.href="/api/users/login";</script>',
+        );
+    }
+  };
+}

--- a/src/common/responses/response.ts
+++ b/src/common/responses/response.ts
@@ -1,0 +1,10 @@
+export interface ApiResponse<T> {
+    resultType: "SUCCESS";
+    error: null;
+    data: T;
+  }
+  export const success = <T>(data: T): ApiResponse<T> => ({
+    resultType: "SUCCESS",
+    error: null,
+    data,
+  });

--- a/src/generated/routes.ts
+++ b/src/generated/routes.ts
@@ -5,6 +5,18 @@ import type { TsoaRoute } from '@tsoa/runtime';
 import {  fetchMiddlewares, ExpressTemplateService } from '@tsoa/runtime';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { UserController } from './../modules/users/controllers/user.controller.js';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { ShopController } from './../modules/shops/controllers/shop.controller.js';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { ReviewController } from './../modules/reviews/controllers/review.controller.js';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { UserReviewController } from './../modules/reviews/controllers/review.controller.js';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { ShopMissionController } from './../modules/missions/controllers/mission.controller.js';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { MissionController } from './../modules/missions/controllers/mission.controller.js';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { UserMissionController } from './../modules/missions/controllers/mission.controller.js';
 import type { Request as ExRequest, Response as ExResponse, RequestHandler, Router } from 'express';
 
 
@@ -45,6 +57,224 @@ const models: TsoaRoute.Models = {
             "email": {"dataType":"string","required":true},
             "preferences": {"dataType":"array","array":{"dataType":"double"},"required":true},
             "password": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ShopResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "shop_id": {"dataType":"double","required":true},
+            "owner_id": {"dataType":"double","required":true},
+            "region_id": {"dataType":"double","required":true},
+            "region_name": {"dataType":"string","required":true},
+            "shop_name": {"dataType":"string","required":true},
+            "shop_position": {"dataType":"string","required":true},
+            "shop_explain": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
+            "shop_phone": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
+            "status": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiResponse_ShopResponse_": {
+        "dataType": "refObject",
+        "properties": {
+            "resultType": {"dataType":"enum","enums":["SUCCESS"],"required":true},
+            "error": {"dataType":"enum","enums":[null],"required":true},
+            "data": {"ref":"ShopResponse","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ShopCreateRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "owner_id": {"dataType":"double","required":true},
+            "region_id": {"dataType":"double","required":true},
+            "shop_name": {"dataType":"string","required":true},
+            "shop_position": {"dataType":"string","required":true},
+            "shop_explain": {"dataType":"string"},
+            "shop_phone": {"dataType":"string"},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ReviewCreateResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "review_id": {"dataType":"double","required":true},
+            "shop_id": {"dataType":"double","required":true},
+            "user_id": {"dataType":"double","required":true},
+            "nickname": {"dataType":"string","required":true},
+            "rating": {"dataType":"double","required":true},
+            "body": {"dataType":"string","required":true},
+            "image_urls": {"dataType":"array","array":{"dataType":"string"},"required":true},
+            "created_date": {"dataType":"datetime","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiResponse_ReviewCreateResponse_": {
+        "dataType": "refObject",
+        "properties": {
+            "resultType": {"dataType":"enum","enums":["SUCCESS"],"required":true},
+            "error": {"dataType":"enum","enums":[null],"required":true},
+            "data": {"ref":"ReviewCreateResponse","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ReviewCreateRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "user_id": {"dataType":"double","required":true},
+            "user_mission_id": {"dataType":"double","required":true},
+            "rating": {"dataType":"double","required":true},
+            "body": {"dataType":"string","required":true},
+            "image_urls": {"dataType":"array","array":{"dataType":"string"}},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ReviewsListResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "data": {"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"created_date":{"dataType":"datetime","required":true},"body":{"dataType":"string","required":true},"rating":{"dataType":"double","required":true},"nickname":{"dataType":"string","required":true},"review_id":{"dataType":"double","required":true}}},"required":true},
+            "pagination": {"dataType":"nestedObjectLiteral","nestedProperties":{"cursor":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true}},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiResponse_ReviewsListResponse_": {
+        "dataType": "refObject",
+        "properties": {
+            "resultType": {"dataType":"enum","enums":["SUCCESS"],"required":true},
+            "error": {"dataType":"enum","enums":[null],"required":true},
+            "data": {"ref":"ReviewsListResponse","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "MyReviewsListResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "data": {"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"created_date":{"dataType":"datetime","required":true},"body":{"dataType":"string","required":true},"rating":{"dataType":"double","required":true},"shop_name":{"dataType":"string","required":true},"shop_id":{"dataType":"double","required":true},"review_id":{"dataType":"double","required":true}}},"required":true},
+            "pagination": {"dataType":"nestedObjectLiteral","nestedProperties":{"cursor":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true}},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiResponse_MyReviewsListResponse_": {
+        "dataType": "refObject",
+        "properties": {
+            "resultType": {"dataType":"enum","enums":["SUCCESS"],"required":true},
+            "error": {"dataType":"enum","enums":[null],"required":true},
+            "data": {"ref":"MyReviewsListResponse","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "MissionResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "mission_id": {"dataType":"double","required":true},
+            "shop_id": {"dataType":"double","required":true},
+            "title": {"dataType":"string","required":true},
+            "body": {"dataType":"string","required":true},
+            "point": {"dataType":"double","required":true},
+            "status": {"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},
+            "created_date": {"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"enum","enums":[null]}],"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiResponse_MissionResponse_": {
+        "dataType": "refObject",
+        "properties": {
+            "resultType": {"dataType":"enum","enums":["SUCCESS"],"required":true},
+            "error": {"dataType":"enum","enums":[null],"required":true},
+            "data": {"ref":"MissionResponse","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "MissionCreateRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "shop_id": {"dataType":"double","required":true},
+            "title": {"dataType":"string","required":true},
+            "body": {"dataType":"string","required":true},
+            "point": {"dataType":"double","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "MissionsListResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "data": {"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"created_date":{"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"enum","enums":[null]}],"required":true},"status":{"dataType":"union","subSchemas":[{"dataType":"string"},{"dataType":"enum","enums":[null]}],"required":true},"point":{"dataType":"double","required":true},"body":{"dataType":"string","required":true},"title":{"dataType":"string","required":true},"shop_id":{"dataType":"double","required":true},"mission_id":{"dataType":"double","required":true}}},"required":true},
+            "pagination": {"dataType":"nestedObjectLiteral","nestedProperties":{"cursor":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true}},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiResponse_MissionsListResponse_": {
+        "dataType": "refObject",
+        "properties": {
+            "resultType": {"dataType":"enum","enums":["SUCCESS"],"required":true},
+            "error": {"dataType":"enum","enums":[null],"required":true},
+            "data": {"ref":"MissionsListResponse","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "UserMissionResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "user_mission_id": {"dataType":"double","required":true},
+            "user_id": {"dataType":"double","required":true},
+            "mission_id": {"dataType":"double","required":true},
+            "status": {"dataType":"string","required":true},
+            "created_date": {"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"enum","enums":[null]}],"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiResponse_UserMissionResponse_": {
+        "dataType": "refObject",
+        "properties": {
+            "resultType": {"dataType":"enum","enums":["SUCCESS"],"required":true},
+            "error": {"dataType":"enum","enums":[null],"required":true},
+            "data": {"ref":"UserMissionResponse","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "UserMissionCreateRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "user_id": {"dataType":"double","required":true},
+            "mission_id": {"dataType":"double","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "InProgressMissionsListResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "data": {"dataType":"array","array":{"dataType":"nestedObjectLiteral","nestedProperties":{"created_date":{"dataType":"union","subSchemas":[{"dataType":"datetime"},{"dataType":"enum","enums":[null]}],"required":true},"status":{"dataType":"string","required":true},"point":{"dataType":"double","required":true},"body":{"dataType":"string","required":true},"title":{"dataType":"string","required":true},"shop_id":{"dataType":"double","required":true},"mission_id":{"dataType":"double","required":true},"user_mission_id":{"dataType":"double","required":true}}},"required":true},
+            "pagination": {"dataType":"nestedObjectLiteral","nestedProperties":{"cursor":{"dataType":"union","subSchemas":[{"dataType":"double"},{"dataType":"enum","enums":[null]}],"required":true}},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiResponse_InProgressMissionsListResponse_": {
+        "dataType": "refObject",
+        "properties": {
+            "resultType": {"dataType":"enum","enums":["SUCCESS"],"required":true},
+            "error": {"dataType":"enum","enums":[null],"required":true},
+            "data": {"ref":"InProgressMissionsListResponse","required":true},
         },
         "additionalProperties": false,
     },
@@ -233,6 +463,284 @@ export function RegisterRoutes(app: Router) {
 
               await templateService.apiHandler({
                 methodName: 'handleSetLogout',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsShopController_handleCreateShop: Record<string, TsoaRoute.ParameterSchema> = {
+                regionId: {"in":"path","name":"regionId","required":true,"dataType":"double"},
+                body: {"in":"body","name":"body","required":true,"ref":"ShopCreateRequest"},
+        };
+        app.post('/regions/:regionId/shops',
+            ...(fetchMiddlewares<RequestHandler>(ShopController)),
+            ...(fetchMiddlewares<RequestHandler>(ShopController.prototype.handleCreateShop)),
+
+            async function ShopController_handleCreateShop(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsShopController_handleCreateShop, request, response });
+
+                const controller = new ShopController();
+
+              await templateService.apiHandler({
+                methodName: 'handleCreateShop',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsReviewController_handleCreateReview: Record<string, TsoaRoute.ParameterSchema> = {
+                shopId: {"in":"path","name":"shopId","required":true,"dataType":"double"},
+                body: {"in":"body","name":"body","required":true,"ref":"ReviewCreateRequest"},
+        };
+        app.post('/shops/:shopId/reviews',
+            ...(fetchMiddlewares<RequestHandler>(ReviewController)),
+            ...(fetchMiddlewares<RequestHandler>(ReviewController.prototype.handleCreateReview)),
+
+            async function ReviewController_handleCreateReview(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsReviewController_handleCreateReview, request, response });
+
+                const controller = new ReviewController();
+
+              await templateService.apiHandler({
+                methodName: 'handleCreateReview',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsReviewController_handleGetReviews: Record<string, TsoaRoute.ParameterSchema> = {
+                shopId: {"in":"path","name":"shopId","required":true,"dataType":"double"},
+                cursor: {"default":0,"in":"query","name":"cursor","dataType":"double"},
+        };
+        app.get('/shops/:shopId/reviews',
+            ...(fetchMiddlewares<RequestHandler>(ReviewController)),
+            ...(fetchMiddlewares<RequestHandler>(ReviewController.prototype.handleGetReviews)),
+
+            async function ReviewController_handleGetReviews(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsReviewController_handleGetReviews, request, response });
+
+                const controller = new ReviewController();
+
+              await templateService.apiHandler({
+                methodName: 'handleGetReviews',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsUserReviewController_handleGetMyReviews: Record<string, TsoaRoute.ParameterSchema> = {
+                userId: {"in":"path","name":"userId","required":true,"dataType":"double"},
+                cursor: {"default":0,"in":"query","name":"cursor","dataType":"double"},
+        };
+        app.get('/users/:userId/reviews',
+            ...(fetchMiddlewares<RequestHandler>(UserReviewController)),
+            ...(fetchMiddlewares<RequestHandler>(UserReviewController.prototype.handleGetMyReviews)),
+
+            async function UserReviewController_handleGetMyReviews(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsUserReviewController_handleGetMyReviews, request, response });
+
+                const controller = new UserReviewController();
+
+              await templateService.apiHandler({
+                methodName: 'handleGetMyReviews',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsShopMissionController_handleCreateMission: Record<string, TsoaRoute.ParameterSchema> = {
+                shopId: {"in":"path","name":"shopId","required":true,"dataType":"double"},
+                body: {"in":"body","name":"body","required":true,"ref":"MissionCreateRequest"},
+        };
+        app.post('/shops/:shopId/missions',
+            ...(fetchMiddlewares<RequestHandler>(ShopMissionController)),
+            ...(fetchMiddlewares<RequestHandler>(ShopMissionController.prototype.handleCreateMission)),
+
+            async function ShopMissionController_handleCreateMission(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsShopMissionController_handleCreateMission, request, response });
+
+                const controller = new ShopMissionController();
+
+              await templateService.apiHandler({
+                methodName: 'handleCreateMission',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsShopMissionController_handleGetMissions: Record<string, TsoaRoute.ParameterSchema> = {
+                shopId: {"in":"path","name":"shopId","required":true,"dataType":"double"},
+                cursor: {"default":0,"in":"query","name":"cursor","dataType":"double"},
+        };
+        app.get('/shops/:shopId/missions',
+            ...(fetchMiddlewares<RequestHandler>(ShopMissionController)),
+            ...(fetchMiddlewares<RequestHandler>(ShopMissionController.prototype.handleGetMissions)),
+
+            async function ShopMissionController_handleGetMissions(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsShopMissionController_handleGetMissions, request, response });
+
+                const controller = new ShopMissionController();
+
+              await templateService.apiHandler({
+                methodName: 'handleGetMissions',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsMissionController_handleChallengeMission: Record<string, TsoaRoute.ParameterSchema> = {
+                body: {"in":"body","name":"body","required":true,"ref":"UserMissionCreateRequest"},
+        };
+        app.post('/missions/challenge',
+            ...(fetchMiddlewares<RequestHandler>(MissionController)),
+            ...(fetchMiddlewares<RequestHandler>(MissionController.prototype.handleChallengeMission)),
+
+            async function MissionController_handleChallengeMission(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsMissionController_handleChallengeMission, request, response });
+
+                const controller = new MissionController();
+
+              await templateService.apiHandler({
+                methodName: 'handleChallengeMission',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsUserMissionController_handleGetInProgressMissions: Record<string, TsoaRoute.ParameterSchema> = {
+                userId: {"in":"path","name":"userId","required":true,"dataType":"double"},
+                cursor: {"default":0,"in":"query","name":"cursor","dataType":"double"},
+        };
+        app.get('/users/:userId/missions/in-progress',
+            ...(fetchMiddlewares<RequestHandler>(UserMissionController)),
+            ...(fetchMiddlewares<RequestHandler>(UserMissionController.prototype.handleGetInProgressMissions)),
+
+            async function UserMissionController_handleGetInProgressMissions(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsUserMissionController_handleGetInProgressMissions, request, response });
+
+                const controller = new UserMissionController();
+
+              await templateService.apiHandler({
+                methodName: 'handleGetInProgressMissions',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsUserMissionController_handleCompleteInProgressMission: Record<string, TsoaRoute.ParameterSchema> = {
+                userId: {"in":"path","name":"userId","required":true,"dataType":"double"},
+                userMissionId: {"in":"path","name":"userMissionId","required":true,"dataType":"double"},
+        };
+        app.patch('/users/:userId/missions/:userMissionId/complete',
+            ...(fetchMiddlewares<RequestHandler>(UserMissionController)),
+            ...(fetchMiddlewares<RequestHandler>(UserMissionController.prototype.handleCompleteInProgressMission)),
+
+            async function UserMissionController_handleCompleteInProgressMission(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsUserMissionController_handleCompleteInProgressMission, request, response });
+
+                const controller = new UserMissionController();
+
+              await templateService.apiHandler({
+                methodName: 'handleCompleteInProgressMission',
                 controller,
                 response,
                 next,

--- a/src/generated/routes.ts
+++ b/src/generated/routes.ts
@@ -1,0 +1,254 @@
+/* tslint:disable */
+/* eslint-disable */
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import type { TsoaRoute } from '@tsoa/runtime';
+import {  fetchMiddlewares, ExpressTemplateService } from '@tsoa/runtime';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { UserController } from './../modules/users/controllers/user.controller.js';
+import type { Request as ExRequest, Response as ExResponse, RequestHandler, Router } from 'express';
+
+
+
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+const models: TsoaRoute.Models = {
+    "UserSignUpResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "userId": {"dataType":"double","required":true},
+            "preferences": {"dataType":"array","array":{"dataType":"string"},"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiResponse_UserSignUpResponse_": {
+        "dataType": "refObject",
+        "properties": {
+            "resultType": {"dataType":"enum","enums":["SUCCESS"],"required":true},
+            "error": {"dataType":"enum","enums":[null],"required":true},
+            "data": {"ref":"UserSignUpResponse","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "UserSignUpRequest": {
+        "dataType": "refObject",
+        "properties": {
+            "user_name": {"dataType":"string","required":true},
+            "nickname": {"dataType":"string","required":true},
+            "user_phone": {"dataType":"string","required":true},
+            "user_gender": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["여성"]},{"dataType":"enum","enums":["남성"]}],"required":true},
+            "birth_data": {"dataType":"string","required":true},
+            "address": {"dataType":"string","required":true},
+            "role": {"dataType":"union","subSchemas":[{"dataType":"enum","enums":["일반 사용자"]},{"dataType":"enum","enums":["가게 운영자"]}],"required":true},
+            "point": {"dataType":"double","required":true},
+            "email": {"dataType":"string","required":true},
+            "preferences": {"dataType":"array","array":{"dataType":"double"},"required":true},
+            "password": {"dataType":"string","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+};
+const templateService = new ExpressTemplateService(models, {"noImplicitAdditionalProperties":"throw-on-extras","bodyCoercion":true});
+
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+
+
+
+export function RegisterRoutes(app: Router) {
+
+    // ###########################################################################################################
+    //  NOTE: If you do not see routes for all of your controllers in this file, then you might not have informed tsoa of where to look
+    //      Please look into the "controllerPathGlobs" config option described in the readme: https://github.com/lukeautry/tsoa
+    // ###########################################################################################################
+
+
+    
+        const argsUserController_handleUserSignUp: Record<string, TsoaRoute.ParameterSchema> = {
+                body: {"in":"body","name":"body","required":true,"ref":"UserSignUpRequest"},
+        };
+        app.post('/users/signup',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.handleUserSignUp)),
+
+            async function UserController_handleUserSignUp(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsUserController_handleUserSignUp, request, response });
+
+                const controller = new UserController();
+
+              await templateService.apiHandler({
+                methodName: 'handleUserSignUp',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsUserController_handleGuestPage: Record<string, TsoaRoute.ParameterSchema> = {
+        };
+        app.get('/users/guest',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.handleGuestPage)),
+
+            async function UserController_handleGuestPage(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsUserController_handleGuestPage, request, response });
+
+                const controller = new UserController();
+
+              await templateService.apiHandler({
+                methodName: 'handleGuestPage',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsUserController_handleLoginPage: Record<string, TsoaRoute.ParameterSchema> = {
+        };
+        app.get('/users/login',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.handleLoginPage)),
+
+            async function UserController_handleLoginPage(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsUserController_handleLoginPage, request, response });
+
+                const controller = new UserController();
+
+              await templateService.apiHandler({
+                methodName: 'handleLoginPage',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsUserController_handleMypage: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+        };
+        app.get('/users/mypage',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.handleMypage)),
+
+            async function UserController_handleMypage(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsUserController_handleMypage, request, response });
+
+                const controller = new UserController();
+
+              await templateService.apiHandler({
+                methodName: 'handleMypage',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsUserController_handleSetLogin: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+        };
+        app.get('/users/set-login',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.handleSetLogin)),
+
+            async function UserController_handleSetLogin(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsUserController_handleSetLogin, request, response });
+
+                const controller = new UserController();
+
+              await templateService.apiHandler({
+                methodName: 'handleSetLogin',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+        const argsUserController_handleSetLogout: Record<string, TsoaRoute.ParameterSchema> = {
+                req: {"in":"request","name":"req","required":true,"dataType":"object"},
+        };
+        app.get('/users/set-logout',
+            ...(fetchMiddlewares<RequestHandler>(UserController)),
+            ...(fetchMiddlewares<RequestHandler>(UserController.prototype.handleSetLogout)),
+
+            async function UserController_handleSetLogout(request: ExRequest, response: ExResponse, next: any) {
+
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({ args: argsUserController_handleSetLogout, request, response });
+
+                const controller = new UserController();
+
+              await templateService.apiHandler({
+                methodName: 'handleSetLogout',
+                controller,
+                response,
+                next,
+                validatedArgs,
+                successStatus: undefined,
+              });
+            } catch (err) {
+                return next(err);
+            }
+        });
+        // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+}
+
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,9 @@
 import dotenv from "dotenv";
-import express, { Express, Request, Response, NextFunction } from "express";
+import express, { Express, NextFunction, Request, Response } from "express";
 import cors from "cors";
-import { handleUserSignUp } from "./modules/users/controllers/user.controller.js";
-import {
-  handleCreateReview,
-  handleGetMyReviews,
-  handleGetReviews,
-} from "./modules/reviews/controllers/review.controller.js";
-import {
-  handleCreateMission,
-  handleChallengeMission,
-  handleCompleteInProgressMission,
-  handleGetInProgressMissions,
-  handleGetMissions,
-} from "./modules/missions/controllers/mission.controller.js";
-import { handleCreateShop } from "./modules/shops/controllers/shop.controller.js";
+import cookieParser from "cookie-parser";
+import { RegisterRoutes } from "./generated/routes.js";
+import { AppError } from "./common/errors/app.error.js";
 
 // 1. 환경 변수 설정
 dotenv.config();
@@ -22,33 +11,42 @@ dotenv.config();
 const app: Express = express();
 const port = process.env.PORT || 3000;
 
+app.use((req: Request, res: Response, next: NextFunction) => {
+  (res as any).error = function ({ errorCode = null, message = null, data = null }) {
+    return this.json({
+      resultType: "FAILED",
+      error: { errorCode, message, data },
+      data: null,
+    });
+  };
+  next();
+});
+
 // 2. 미들웨어 설정
 app.use(cors());            // cors 방식 허용                 
 app.use(express.static('public'));    // 정적 파일 접근      
 app.use(express.json());              // request의 본문을 json으로 해석할 수 있도록 함(JSON 형태의 요청 body를 파싱하기 위함)     
 app.use(express.urlencoded({ extended: false })); // 단순 객체 문자열 형태로 본문 데이터 해석
+app.use(cookieParser()); // req.cookies 사용 (cookie-parser)
 
-// 3. 기본 라우트
-app.get("/", (req: Request, res: Response) => {
-  res.send("Hello World! This is TypeScript Server!");
-});
+// Express.js에 생성한 엔드 포인트들을 register
+const router = express.Router();
+RegisterRoutes(router);
+app.use("/api/v1", router);
 
-app.post("/users", handleUserSignUp);
-app.post("/shops/:shopId/reviews", handleCreateReview);
-app.post("/missions/challenge", handleChallengeMission);
-app.post("/regions/:regionId/shops", handleCreateShop);
-app.post("/shops/:shopId/missions", handleCreateMission);
-app.get("/shops/:shopId/missions", handleGetMissions);
-app.get("/users/:userId/missions/in-progress", handleGetInProgressMissions);
-app.patch("/users/:userId/missions/:userMissionId/complete", handleCompleteInProgressMission);
-app.get("/shops/:shopId/reviews", handleGetReviews);
-app.get("/users/:userId/reviews", handleGetMyReviews);
+/**
+ * 전역 오류를 처리하기 위한 미들웨어
+ */
+app.use((err: AppError, req: Request, res: Response, next: NextFunction) => {
+  if (res.headersSent) {
+    return next(err);
+  }
 
-
-// 전역 에러 핸들러
-app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
-  console.error(err.message);
-  res.status(500).json({ isSuccess: false, code: "COMMON000", message: err.message });
+  (res.status(err.statusCode || 500) as any).error({
+    errorCode: err.errorCode || "unknown",
+    message: err.message || null,
+    data: err.data || null,
+  });
 });
 
 // 4. 서버 시작

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,18 +36,68 @@ const router = express.Router();
 RegisterRoutes(router);
 app.use("/api/v1", router);
 
+function isAppError(err: unknown): err is AppError {
+  return err instanceof AppError;
+}
+
+/** Prisma 등에서 나온 긴 기술 메시지는 클라이언트에 그대로 노출하지 않음 */
+function clientSafeErrorPayload(err: unknown): { statusCode: number; errorCode: string; message: string; data: unknown } {
+  if (isAppError(err)) {
+    return {
+      statusCode: err.statusCode || 500,
+      errorCode: err.errorCode || "UNKNOWN",
+      message: err.message || "오류가 발생했습니다.",
+      data: err.data ?? null,
+    };
+  }
+
+  console.error(err);
+
+  if (err instanceof Error) {
+    const m = err.message;
+    const isPrismaLike =
+      m.includes("Invalid `prisma.") ||
+      /foreign key constraint/i.test(m) ||
+      /unique constraint/i.test(m);
+
+    if (isPrismaLike) {
+      return {
+        statusCode: 400,
+        errorCode: "COMMON400",
+        message: "요청 값이 데이터베이스 조건과 맞지 않습니다. 참조 ID·중복 여부 등을 확인해 주세요.",
+        data: null,
+      };
+    }
+
+    return {
+      statusCode: 500,
+      errorCode: "COMMON500",
+      message: m || "서버 오류가 발생했습니다.",
+      data: null,
+    };
+  }
+
+  return {
+    statusCode: 500,
+    errorCode: "COMMON500",
+    message: "알 수 없는 오류가 발생했습니다.",
+    data: null,
+  };
+}
+
 /**
  * 전역 오류를 처리하기 위한 미들웨어
  */
-app.use((err: AppError, req: Request, res: Response, next: NextFunction) => {
+app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
   if (res.headersSent) {
     return next(err);
   }
 
-  (res.status(err.statusCode || 500) as any).error({
-    errorCode: err.errorCode || "unknown",
-    message: err.message || null,
-    data: err.data || null,
+  const payload = clientSafeErrorPayload(err);
+  (res.status(payload.statusCode) as any).error({
+    errorCode: payload.errorCode,
+    message: payload.message,
+    data: payload.data,
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import dotenv from "dotenv";
 import express, { Express, NextFunction, Request, Response } from "express";
 import cors from "cors";
 import cookieParser from "cookie-parser";
+import morgan from "morgan";
 import { RegisterRoutes } from "./generated/routes.js";
 import { AppError } from "./common/errors/app.error.js";
 
@@ -23,11 +24,12 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 });
 
 // 2. 미들웨어 설정
-app.use(cors());            // cors 방식 허용                 
-app.use(express.static('public'));    // 정적 파일 접근      
-app.use(express.json());              // request의 본문을 json으로 해석할 수 있도록 함(JSON 형태의 요청 body를 파싱하기 위함)     
+app.use(morgan("dev"));               // HTTP 요청 로깅 (morgan)
+app.use(cors());                      // cors 방식 허용
+app.use(express.static('public'));    // 정적 파일 접근
+app.use(express.json());              // request의 본문을 json으로 해석할 수 있도록 함(JSON 형태의 요청 body를 파싱하기 위함)
 app.use(express.urlencoded({ extended: false })); // 단순 객체 문자열 형태로 본문 데이터 해석
-app.use(cookieParser()); // req.cookies 사용 (cookie-parser)
+app.use(cookieParser());              // req.cookies 사용 (cookie-parser)
 
 // Express.js에 생성한 엔드 포인트들을 register
 const router = express.Router();

--- a/src/modules/missions/controllers/mission.controller.ts
+++ b/src/modules/missions/controllers/mission.controller.ts
@@ -1,10 +1,14 @@
-import { Request, Response, NextFunction } from "express";
-import { StatusCodes } from "http-status-codes";
+import { Body, Controller, Get, Patch, Path, Post, Query, Route, Tags } from "tsoa";
+import { ApiResponse, success } from "../../../common/responses/response.js";
 import {
   bodyToMission,
   bodyToUserMission,
+  InProgressMissionsListResponse,
   MissionCreateRequest,
+  MissionResponse,
+  MissionsListResponse,
   UserMissionCreateRequest,
+  UserMissionResponse,
 } from "../dtos/mission.dto.js";
 import {
   challengeMission,
@@ -14,126 +18,60 @@ import {
   getMissions,
 } from "../services/mission.service.js";
 
-// 가게에 미션 추가
-export const handleCreateMission = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
-    const shopId = parseInt(req.params["shopId"] as string);
-    if (isNaN(shopId)) {
-      res.status(StatusCodes.BAD_REQUEST).json({ error: "유효하지 않은 가게 ID입니다." });
-      return;
-    }
-    const data = bodyToMission(req.body as MissionCreateRequest, shopId);
+@Route("shops")
+@Tags("Missions")
+export class ShopMissionController extends Controller {
+  @Post("{shopId}/missions")
+  public async handleCreateMission(
+    @Path() shopId: number,
+    @Body() body: MissionCreateRequest,
+  ): Promise<ApiResponse<MissionResponse>> {
+    const data = bodyToMission(body, shopId);
     const mission = await createMission(data);
-    res.status(StatusCodes.OK).json({ result: mission });
-  } catch (err) {
-    next(err);
+    return success(mission);
   }
-};
 
-// 미션 도전하기ㅣㅣ
-export const handleChallengeMission = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
-    const data = bodyToUserMission(req.body as UserMissionCreateRequest);
-    const userMission = await challengeMission(data);
-    res.status(StatusCodes.OK).json({ result: userMission });
-  } catch (err) {
-    next(err);
-  }
-};
-
-export const handleGetMissions = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
-    const shopIdParam = req.params["shopId"];
-    if (!shopIdParam) {
-      res.status(StatusCodes.BAD_REQUEST).json({ error: "가게 ID가 없습니다." });
-      return;
-    }
-
-    const shopId = parseInt(shopIdParam as string);
-    if (isNaN(shopId)) {
-      res.status(StatusCodes.BAD_REQUEST).json({ error: "유효하지 않은 가게 ID입니다." });
-      return;
-    }
-
-    const cursor =
-      typeof req.query["cursor"] === "string"
-        ? parseInt(req.query["cursor"], 10)
-        : 0;
-
+  @Get("{shopId}/missions")
+  public async handleGetMissions(
+    @Path() shopId: number,
+    @Query() cursor: number = 0,
+  ): Promise<ApiResponse<MissionsListResponse>> {
     const result = await getMissions(shopId, cursor);
-    res.status(StatusCodes.OK).json({ result });
-  } catch (err) {
-    next(err);
+    return success(result);
   }
-};
+}
 
-export const handleGetInProgressMissions = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
-    const userIdParam = req.params["userId"];
-    if (!userIdParam) {
-      res.status(StatusCodes.BAD_REQUEST).json({ error: "유저 ID가 없습니다." });
-      return;
-    }
+@Route("missions")
+@Tags("Missions")
+export class MissionController extends Controller {
+  @Post("challenge")
+  public async handleChallengeMission(
+    @Body() body: UserMissionCreateRequest,
+  ): Promise<ApiResponse<UserMissionResponse>> {
+    const data = bodyToUserMission(body);
+    const userMission = await challengeMission(data);
+    return success(userMission);
+  }
+}
 
-    const userId = parseInt(userIdParam as string);
-    if (isNaN(userId)) {
-      res.status(StatusCodes.BAD_REQUEST).json({ error: "유효하지 않은 유저 ID입니다." });
-      return;
-    }
-
-    const cursor =
-      typeof req.query["cursor"] === "string"
-        ? parseInt(req.query["cursor"], 10)
-        : 0;
-
+@Route("users")
+@Tags("Missions")
+export class UserMissionController extends Controller {
+  @Get("{userId}/missions/in-progress")
+  public async handleGetInProgressMissions(
+    @Path() userId: number,
+    @Query() cursor: number = 0,
+  ): Promise<ApiResponse<InProgressMissionsListResponse>> {
     const result = await getInProgressMissions(userId, cursor);
-    res.status(StatusCodes.OK).json({ result });
-  } catch (err) {
-    next(err);
+    return success(result);
   }
-};
 
-export const handleCompleteInProgressMission = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
-    const userIdParam = req.params["userId"];
-    const userMissionIdParam = req.params["userMissionId"];
-
-    if (!userIdParam || !userMissionIdParam) {
-      res.status(StatusCodes.BAD_REQUEST).json({ error: "유저 ID 또는 유저 미션 ID가 없습니다." });
-      return;
-    }
-
-    const userId = parseInt(userIdParam as string);
-    const userMissionId = parseInt(userMissionIdParam as string);
-
-    if (isNaN(userId) || isNaN(userMissionId)) {
-      res.status(StatusCodes.BAD_REQUEST).json({ error: "유효하지 않은 ID입니다." });
-      return;
-    }
-
+  @Patch("{userId}/missions/{userMissionId}/complete")
+  public async handleCompleteInProgressMission(
+    @Path() userId: number,
+    @Path() userMissionId: number,
+  ): Promise<ApiResponse<UserMissionResponse>> {
     const result = await completeInProgressMission(userId, userMissionId);
-    res.status(StatusCodes.OK).json({ result });
-  } catch (err) {
-    next(err);
+    return success(result);
   }
-};
+}

--- a/src/modules/missions/dtos/mission.dto.ts
+++ b/src/modules/missions/dtos/mission.dto.ts
@@ -5,6 +5,29 @@ export interface MissionCreateRequest {
   point: number;
 }
 
+export interface MissionResponse {
+  mission_id: number;
+  shop_id: number;
+  title: string;
+  body: string;
+  point: number;
+  status: string | null;
+  created_date: Date | null;
+}
+
+export interface MissionsListResponse {
+  data: Array<{
+    mission_id: number;
+    shop_id: number;
+    title: string;
+    body: string;
+    point: number;
+    status: string | null;
+    created_date: Date | null;
+  }>;
+  pagination: { cursor: number | null };
+}
+
 export const bodyToMission = (body: MissionCreateRequest, shopId: number) => {
   return {
     shop_id: shopId,
@@ -47,6 +70,28 @@ export const responseFromMissions = (missions: any[]) => {
 export interface UserMissionCreateRequest {
   user_id: number;
   mission_id: number;
+}
+
+export interface UserMissionResponse {
+  user_mission_id: number;
+  user_id: number;
+  mission_id: number;
+  status: string;
+  created_date: Date | null;
+}
+
+export interface InProgressMissionsListResponse {
+  data: Array<{
+    user_mission_id: number;
+    mission_id: number;
+    shop_id: number;
+    title: string;
+    body: string;
+    point: number;
+    status: string;
+    created_date: Date | null;
+  }>;
+  pagination: { cursor: number | null };
 }
 
 export const bodyToUserMission = (body: UserMissionCreateRequest) => {

--- a/src/modules/missions/repositories/mission.repository.ts
+++ b/src/modules/missions/repositories/mission.repository.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../../../db.config.js";
+import { InternalServerError } from "../../../common/errors/error.js";
 
 // 가게 존재 여부 확인
 export const checkShopExists = async (shopId: number): Promise<boolean> => {
@@ -24,7 +25,10 @@ export const addMission = async (data: {
     });
     return Number(created.id);
   } catch (err) {
-    throw new Error(`미션 추가 오류: ${err}`);
+    throw new InternalServerError("미션 추가 중 오류가 발생했습니다.", {
+      data,
+      cause: err instanceof Error ? err.message : String(err),
+    });
   }
 };
 
@@ -83,7 +87,10 @@ export const addUserMission = async (data: {
     });
     return Number(created.id);
   } catch (err) {
-    throw new Error(`미션 도전 오류: ${err}`);
+    throw new InternalServerError("미션 도전 중 오류가 발생했습니다.", {
+      data,
+      cause: err instanceof Error ? err.message : String(err),
+    });
   }
 };
 

--- a/src/modules/missions/services/mission.service.ts
+++ b/src/modules/missions/services/mission.service.ts
@@ -6,6 +6,7 @@ import {
   responseFromMissions,
   responseFromUserMission,
 } from "../dtos/mission.dto.js";
+import { ConflictError, NotFoundError, ValidationError } from "../../../common/errors/error.js";
 import {
   addMission,
   addUserMission,
@@ -26,7 +27,7 @@ export const createMission = async (data: ReturnType<typeof bodyToMission>) => {
   // 1. 가게 존재 여부 확인
   const shopExists = await checkShopExists(data.shop_id);
   if (!shopExists) {
-    throw new Error("존재하지 않는 가게입니다.");
+    throw new NotFoundError("존재하지 않는 가게입니다.", { shopId: data.shop_id });
   }
 
   // 2. 미션 삽입
@@ -41,13 +42,13 @@ export const challengeMission = async (data: ReturnType<typeof bodyToUserMission
   // 1. 미션 존재 여부 확인
   const missionExists = await checkMissionExists(data.mission_id);
   if (!missionExists) {
-    throw new Error("존재하지 않는 미션입니다.");
+    throw new NotFoundError("존재하지 않는 미션입니다.", { missionId: data.mission_id });
   }
 
   // 2. 이미 도전 중인지 확인
   const isInProgress = await checkUserMissionInProgress(data.user_id, data.mission_id);
   if (isInProgress) {
-    throw new Error("이미 도전 중인 미션입니다.");
+    throw new ConflictError("이미 도전 중인 미션입니다.", { userId: data.user_id, missionId: data.mission_id });
   }
 
   // 3. user_mission 삽입
@@ -62,7 +63,7 @@ export const getMissions = async (shopId: number, cursor: number) => {
   // 0. 가게 존재 여부 확인
   const shopExists = await checkShopExists(shopId);
   if (!shopExists) {
-    throw new Error("존재하지 않는 가게입니다.");
+    throw new NotFoundError("존재하지 않는 가게입니다.", { shopId });
   }
 
   // 1. 미션 목록 조회
@@ -76,7 +77,7 @@ export const getInProgressMissions = async (userId: number, cursor: number) => {
   // 0. 유저 존재 여부 확인
   const userExists = await checkUserExists(userId);
   if (!userExists) {
-    throw new Error("존재하지 않는 유저입니다.");
+    throw new NotFoundError("존재하지 않는 유저입니다.", { userId });
   }
 
   // 1. 진행 중인 미션 목록 조회
@@ -90,13 +91,13 @@ export const completeInProgressMission = async (userId: number, userMissionId: n
   // 0. 유저 존재 여부 확인
   const userExists = await checkUserExists(userId);
   if (!userExists) {
-    throw new Error("존재하지 않는 유저입니다.");
+    throw new NotFoundError("존재하지 않는 유저입니다.", { userId });
   }
 
   // 1. 해당 유저의 user_mission인지 확인
   const userMission = await getUserMissionByIdAndUserId(userId, userMissionId);
   if (!userMission) {
-    throw new Error("존재하지 않는 유저 미션입니다.");
+    throw new NotFoundError("존재하지 않는 유저 미션입니다.", { userId, userMissionId });
   }
 
   // 2. 진행중 상태인지 확인 (이미 성공이면 그대로 반환)
@@ -104,7 +105,11 @@ export const completeInProgressMission = async (userId: number, userMissionId: n
     return responseFromUserMission(userMission);
   }
   if (userMission.status !== "진행중") {
-    throw new Error("진행 중인 미션만 완료 처리할 수 있습니다.");
+    throw new ValidationError("진행 중인 미션만 완료 처리할 수 있습니다.", {
+      userId,
+      userMissionId,
+      status: userMission.status,
+    });
   }
 
   // 3. 완료 처리(성공)

--- a/src/modules/reviews/controllers/review.controller.ts
+++ b/src/modules/reviews/controllers/review.controller.ts
@@ -1,96 +1,50 @@
-import { Request, Response, NextFunction } from "express";
-import { StatusCodes } from "http-status-codes";
-import { bodyToReview, ReviewCreateRequest } from "../dtos/review.dto.js";
+import { Body, Controller, Get, Path, Post, Query, Route, Tags } from "tsoa";
+import { ApiResponse, success } from "../../../common/responses/response.js";
+import {
+  bodyToReview,
+  MyReviewsListResponse,
+  ReviewCreateRequest,
+  ReviewCreateResponse,
+  ReviewsListResponse,
+} from "../dtos/review.dto.js";
 import { createReview, getMyReviews, getReviews } from "../services/review.service.js";
 
-export const handleCreateReview = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
-    const shopIdParam = req.params["shopId"];
-    if (!shopIdParam) {
-      res.status(StatusCodes.BAD_REQUEST).json({ error: "가게 ID가 없습니다." });
-      return;
-    }
-    const shopId = parseInt(shopIdParam as string);
-
-    if (isNaN(shopId)) {
-      res.status(StatusCodes.BAD_REQUEST).json({ error: "유효하지 않은 가게 ID입니다." });
-      return;
-    }
-
-    const data = bodyToReview(req.body as ReviewCreateRequest, shopId);
-
-    const imageFiles = (req.body.image_urls ?? []).map((url: string) => ({
+@Route("shops")
+@Tags("Reviews")
+export class ReviewController extends Controller {
+  @Post("{shopId}/reviews")
+  public async handleCreateReview(
+    @Path() shopId: number,
+    @Body() body: ReviewCreateRequest,
+  ): Promise<ApiResponse<ReviewCreateResponse>> {
+    const data = bodyToReview(body, shopId);
+    const imageFiles = (body.image_urls ?? []).map((url: string) => ({
       s3_url: url,
       s3_key: url.split("/").pop() ?? url,
     }));
-
     const review = await createReview(data, imageFiles);
-    res.status(StatusCodes.OK).json({ result: review });
-  } catch (err) {
-    next(err);
+    return success(review);
   }
-};
 
-export const handleGetReviews = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
-    const shopIdParam = req.params["shopId"];
-    if (!shopIdParam) {
-      res.status(StatusCodes.BAD_REQUEST).json({ error: "가게 ID가 없습니다." });
-      return;
-    }
-
-    const shopId = parseInt(shopIdParam as string);
-    if (isNaN(shopId)) {
-      res.status(StatusCodes.BAD_REQUEST).json({ error: "유효하지 않은 가게 ID입니다." });
-      return;
-    }
-
-    // cursor 타입 안전하게 처리
-    const cursor = typeof req.query["cursor"] === "string"
-      ? parseInt(req.query["cursor"], 10)
-      : 0;
-
+  @Get("{shopId}/reviews")
+  public async handleGetReviews(
+    @Path() shopId: number,
+    @Query() cursor: number = 0,
+  ): Promise<ApiResponse<ReviewsListResponse>> {
     const result = await getReviews(shopId, cursor);
-    res.status(StatusCodes.OK).json({ result });
-  } catch (err) {
-    next(err);
+    return success(result);
   }
-};
+}
 
-export const handleGetMyReviews = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
-    const userIdParam = req.params["userId"];
-    if (!userIdParam) {
-      res.status(StatusCodes.BAD_REQUEST).json({ error: "유저 ID가 없습니다." });
-      return;
-    }
-
-    const userId = parseInt(userIdParam as string);
-    if (isNaN(userId)) {
-      res.status(StatusCodes.BAD_REQUEST).json({ error: "유효하지 않은 유저 ID입니다." });
-      return;
-    }
-
-    const cursor =
-      typeof req.query["cursor"] === "string"
-        ? parseInt(req.query["cursor"], 10)
-        : 0;
-
+@Route("users")
+@Tags("Reviews")
+export class UserReviewController extends Controller {
+  @Get("{userId}/reviews")
+  public async handleGetMyReviews(
+    @Path() userId: number,
+    @Query() cursor: number = 0,
+  ): Promise<ApiResponse<MyReviewsListResponse>> {
     const result = await getMyReviews(userId, cursor);
-    res.status(StatusCodes.OK).json({ result });
-  } catch (err) {
-    next(err);
+    return success(result);
   }
-};
+}

--- a/src/modules/reviews/dtos/review.dto.ts
+++ b/src/modules/reviews/dtos/review.dto.ts
@@ -6,6 +6,40 @@ export interface ReviewCreateRequest {
   image_urls?: string[];
 }
 
+export interface ReviewCreateResponse {
+  review_id: number;
+  shop_id: number;
+  user_id: number;
+  nickname: string;
+  rating: number;
+  body: string;
+  image_urls: string[];
+  created_date: Date;
+}
+
+export interface ReviewsListResponse {
+  data: Array<{
+    review_id: number;
+    nickname: string;
+    rating: number;
+    body: string;
+    created_date: Date;
+  }>;
+  pagination: { cursor: number | null };
+}
+
+export interface MyReviewsListResponse {
+  data: Array<{
+    review_id: number;
+    shop_id: number;
+    shop_name: string;
+    rating: number;
+    body: string;
+    created_date: Date;
+  }>;
+  pagination: { cursor: number | null };
+}
+
 export const bodyToReview = (body: ReviewCreateRequest, shopId: number) => {
   return {
     user_id: body.user_id,

--- a/src/modules/reviews/repositories/review.repository.ts
+++ b/src/modules/reviews/repositories/review.repository.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../../../db.config.js";
+import { InternalServerError } from "../../../common/errors/error.js";
 
 export const checkMissionCompleted = async (
   userId: number,
@@ -42,7 +43,10 @@ export const addReview = async (data: {
     });
     return Number(created.id);
   } catch (err) {
-    throw new Error(`리뷰 삽입 오류: ${err}`);
+    throw new InternalServerError("리뷰 삽입 중 오류가 발생했습니다.", {
+      data,
+      cause: err instanceof Error ? err.message : String(err),
+    });
   }
 };
 
@@ -61,7 +65,11 @@ export const addReviewImages = async (
       })),
     });
   } catch (err) {
-    throw new Error(`이미지 삽입 오류: ${err}`);
+    throw new InternalServerError("리뷰 이미지 삽입 중 오류가 발생했습니다.", {
+      reviewId,
+      imageCount: images.length,
+      cause: err instanceof Error ? err.message : String(err),
+    });
   }
 };
 

--- a/src/modules/reviews/services/review.service.ts
+++ b/src/modules/reviews/services/review.service.ts
@@ -4,6 +4,7 @@ import {
   responseFromReview,
   responseFromReviews,
 } from "../dtos/review.dto.js";
+import { ConflictError, NotFoundError, ValidationError } from "../../../common/errors/error.js";
 import {
   addReview,
   addReviewImages,
@@ -24,7 +25,7 @@ export const createReview = async (
   // 0. 가게 존재 여부 확인 ← 추가
   const shopExists = await checkShopExists(data.shop_id);
   if (!shopExists) {
-    throw new Error("존재하지 않는 가게입니다.");
+    throw new NotFoundError("존재하지 않는 가게입니다.", { shopId: data.shop_id });
   }
 
   // 1. 별점 유효성 검사
@@ -33,7 +34,7 @@ export const createReview = async (
     data.rating > 5.0 ||
     Math.round(data.rating * 2) !== data.rating * 2
   ) {
-    throw new Error("별점은 1.0~5.0 사이의 0.5 단위 숫자여야 합니다.");
+    throw new ValidationError("별점은 1.0~5.0 사이의 0.5 단위 숫자여야 합니다.", { rating: data.rating });
   }
 
   // 2. 미션 성공 여부 확인
@@ -43,13 +44,17 @@ export const createReview = async (
     data.user_mission_id
   );
   if (!isValid) {
-    throw new Error("미션을 성공한 유저만 리뷰를 작성할 수 있습니다.");
+    throw new ValidationError("미션을 성공한 유저만 리뷰를 작성할 수 있습니다.", {
+      userId: data.user_id,
+      shopId: data.shop_id,
+      userMissionId: data.user_mission_id,
+    });
   }
 
   // 3. 중복 리뷰 확인
   const alreadyExists = await checkReviewExists(data.user_mission_id);
   if (alreadyExists) {
-    throw new Error("이미 해당 미션에 대한 리뷰가 존재합니다.");
+    throw new ConflictError("이미 해당 미션에 대한 리뷰가 존재합니다.", { userMissionId: data.user_mission_id });
   }
 
   // 4. 리뷰 삽입
@@ -69,7 +74,7 @@ export const getReviews = async (shopId: number, cursor: number) => {
   // 0. 가게 존재 여부 확인
   const shopExists = await checkShopExists(shopId);
   if (!shopExists) {
-    throw new Error("존재하지 않는 가게입니다.");
+    throw new NotFoundError("존재하지 않는 가게입니다.", { shopId });
   }
 
   // 1. 리뷰 목록 조회
@@ -83,7 +88,7 @@ export const getMyReviews = async (userId: number, cursor: number) => {
   // 0. 유저 존재 여부 확인
   const userExists = await checkUserExists(userId);
   if (!userExists) {
-    throw new Error("존재하지 않는 유저입니다.");
+    throw new NotFoundError("존재하지 않는 유저입니다.", { userId });
   }
 
   // 1. 내가 작성한 리뷰 목록 조회

--- a/src/modules/shops/controllers/shop.controller.ts
+++ b/src/modules/shops/controllers/shop.controller.ts
@@ -1,18 +1,18 @@
-import { Request, Response, NextFunction } from "express";
-import { StatusCodes } from "http-status-codes";
-import { bodyToShop, ShopCreateRequest } from "../dtos/shop.dto.js";
+import { Body, Controller, Path, Post, Route, Tags } from "tsoa";
+import { ApiResponse, success } from "../../../common/responses/response.js";
+import { bodyToShop, ShopCreateRequest, ShopResponse } from "../dtos/shop.dto.js";
 import { createShop } from "../services/shop.service.js";
 
-export const handleCreateShop = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  try {
-    const data = bodyToShop(req.body as ShopCreateRequest);
+@Route("regions")
+@Tags("Shops")
+export class ShopController extends Controller {
+  @Post("{regionId}/shops")
+  public async handleCreateShop(
+    @Path() regionId: number,
+    @Body() body: ShopCreateRequest,
+  ): Promise<ApiResponse<ShopResponse>> {
+    const data = bodyToShop({ ...body, region_id: regionId });
     const shop = await createShop(data);
-    res.status(StatusCodes.OK).json({ result: shop });
-  } catch (err) {
-    next(err);
+    return success(shop);
   }
-};
+}

--- a/src/modules/shops/dtos/shop.dto.ts
+++ b/src/modules/shops/dtos/shop.dto.ts
@@ -7,6 +7,18 @@ export interface ShopCreateRequest {
   shop_phone?: string;
 }
 
+export interface ShopResponse {
+  shop_id: number;
+  owner_id: number;
+  region_id: number;
+  region_name: string;
+  shop_name: string;
+  shop_position: string;
+  shop_explain: string | null;
+  shop_phone: string | null;
+  status: string | null;
+}
+
 export const bodyToShop = (body: ShopCreateRequest) => {
   return {
     owner_id: body.owner_id,

--- a/src/modules/shops/repositories/shop.repository.ts
+++ b/src/modules/shops/repositories/shop.repository.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../../../db.config.js";
+import { InternalServerError } from "../../../common/errors/error.js";
 
 export const checkRegionExists = async (regionId: number): Promise<boolean> => {
   const count = await prisma.region.count({ where: { id: BigInt(regionId) } });
@@ -26,7 +27,10 @@ export const addShop = async (data: {
     });
     return Number(created.id);
   } catch (err) {
-    throw new Error(`가게 추가 오류: ${err}`);
+    throw new InternalServerError("가게 생성 중 오류가 발생했습니다.", {
+      data,
+      cause: err instanceof Error ? err.message : String(err),
+    });
   }
 };
 

--- a/src/modules/shops/services/shop.service.ts
+++ b/src/modules/shops/services/shop.service.ts
@@ -1,4 +1,5 @@
 import { bodyToShop, responseFromShop } from "../dtos/shop.dto.js";
+import { NotFoundError } from "../../../common/errors/error.js";
 import {
   addShop,
   checkRegionExists,
@@ -9,7 +10,7 @@ export const createShop = async (data: ReturnType<typeof bodyToShop>) => {
   // 1. 지역 존재 여부 확인
   const regionExists = await checkRegionExists(data.region_id);
   if (!regionExists) {
-    throw new Error("존재하지 않는 지역입니다.");
+    throw new NotFoundError("존재하지 않는 지역입니다.", { regionId: data.region_id });
   }
 
   // 2. 가게 삽입

--- a/src/modules/users/controllers/user.controller.ts
+++ b/src/modules/users/controllers/user.controller.ts
@@ -1,19 +1,68 @@
-import { Request, Response, NextFunction } from "express";
+import { Body, Controller, Get, Middlewares, Post, Request, Route, Tags } from "tsoa";
+import { Request as ExpressRequest, Response as ExpressResponse, NextFunction } from "express";
 import { StatusCodes } from "http-status-codes";
-import { bodyToUser, UserSignUpRequest } from "../dtos/user.dto.js";
+import { UserSignUpRequest, UserSignUpResponse } from "../dtos/user.dto.js";
 import { userSignUp } from "../services/user.service.js";
+import { authorizeUser } from "../../../common/middlewares/auth.middleware.js";
+import { ApiResponse, success } from "../../../common/responses/response.js";
 
-export const handleUserSignUp = async (req: Request, res: Response, next: NextFunction) => {
-  try {
+@Route("users")
+@Tags("Users")
+export class UserController extends Controller {
+  @Post("signup")
+  public async handleUserSignUp(@Body() body: UserSignUpRequest): Promise<ApiResponse<UserSignUpResponse>> {
     console.log("회원가입을 요청했습니다!");
-    console.log("body:", req.body); // 값이 잘 들어오나 확인하기 위한 테스트용
+    console.log("body:", body);
 
-    //서비스 로직 호출
-    // req.body를 UserSignUpRequest 타입으로 '강제' (Type Assertion) 해줍니다.
-    const user = await userSignUp(bodyToUser(req.body as UserSignUpRequest));
+    const user = await userSignUp(body);
+    return success(user);
+  }
 
-    //성공 응답 보내기
-    res.status(StatusCodes.OK).json({ result: user });
+  @Get("guest")
+  public async handleGuestPage(): Promise<string> {
+    return `
+      <h1>게스트 페이지</h1>
+      <p>이 페이지는 로그인이 필요 없습니다.</p>
+      <ul>
+        <li><a href="/api/users/mypage">마이페이지 (로그인 필요)</a></li>
+      </ul>
+    `;
+  }
+
+  @Get("login")
+  public async handleLoginPage(): Promise<string> {
+    return "<h1>로그인 페이지</h1><p>로그인이 필요한 페이지에서 튕겨나오면 여기로 옵니다.</p>";
+  }
+
+  @Get("mypage")
+  @Middlewares(authorizeUser())
+  public async handleMypage(@Request() req: ExpressRequest): Promise<string> {
+    return `
+      <h1>마이페이지</h1>
+      <p>환영합니다, ${(req as any).cookies?.username}님!</p>
+      <p>이 페이지는 로그인한 사람만 볼 수 있습니다.</p>
+    `;
+  }
+
+  @Get("set-login")
+  public async handleSetLogin(@Request() req: ExpressRequest): Promise<string> {
+    req.res!.cookie("username", "UMC10th", { maxAge: 3600000 });
+    return '로그인 쿠키(username=UMC10th) 생성 완료! <a href="/api/users/mypage">마이페이지로 이동</a>';
+  }
+
+  @Get("set-logout")
+  public async handleSetLogout(@Request() req: ExpressRequest): Promise<string> {
+    req.res!.clearCookie("username");
+    return '로그아웃 완료 (쿠키 삭제). <a href="/api/users/guest">메인으로</a>';
+  }
+}
+
+// 기존 Express 라우팅과의 호환을 위해 유지합니다.
+export const handleUserSignUp = async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
+  try {
+    const controller = new UserController();
+    const result = await controller.handleUserSignUp(req.body as UserSignUpRequest);
+    res.status(StatusCodes.OK).json(result);
   } catch (err) {
     next(err);
   }

--- a/src/modules/users/dtos/user.dto.ts
+++ b/src/modules/users/dtos/user.dto.ts
@@ -8,47 +8,14 @@ export interface UserSignUpRequest {
   birth_data: string;
   address: string;
   role: "일반 사용자" | "가게 운영자";
-  point: bigint;
+  point: number;
   email: string;
   preferences: number[];
   password: string;
   // address?: string;  ?가 붙으면 '없을 수도 있음(선택)'이라는 뜻이에요!
 }
 
-// 2. 요청받은 데이터를 우리 시스템에 맞는 데이터로 변환해주는 함수입니다. 
-export const bodyToUser = (body: UserSignUpRequest) => {
-  const birth_data = new Date(body.birth_data); //날짜 변환
-
-  return {
-    user_name: body.user_name,
-    nickname: body.nickname,
-    user_phone: body.user_phone,
-    user_gender: body.user_gender,    // "여성" | "남성";
-    birth_data,
-    address: body.address,
-    role: body.role,        // "일반 사용자" | "가게 운영자";
-    point: body.point,
-    email: body.email,
-    preferences: body.preferences,
-    password: body.password,
-    // address: body.address || "", //선택 
-  };
-};
-
-// responseFromUser 만들기
-export const responseFromUser = (data: { user: any; preferences?: any[] }) => {
-  const preferCategory = data.preferences?.map((p) => p.foodCategory.name);
-  return {
-    userName: data.user.userName,
-    nickname: data.user.nickname,
-    userPhone: data.user.userPhone,
-    userGender: data.user.userGender,
-    birthData: data.user.birthData,
-    address: data.user.address,
-    role: data.user.role,
-    point: data.user.point,
-    email: data.user.email,
-    preferences: data.user.preferences,
-    preferCategory: preferCategory,
-  };
-};
+export interface UserSignUpResponse {
+  userId: number;
+  preferences: string[];
+}

--- a/src/modules/users/repositories/user.repository.ts
+++ b/src/modules/users/repositories/user.repository.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../../../db.config.js";
+import { InternalServerError } from "../../../common/errors/error.js";
 
 export const addUser = async (data: any): Promise<number | null> => {
   try {
@@ -45,7 +46,10 @@ export const addUser = async (data: any): Promise<number | null> => {
 
     return Number(result.id);
   } catch (err) {
-    throw new Error(`오류가 발생했어요: ${err}`);
+    throw new InternalServerError("유저 생성 중 오류가 발생했습니다.", {
+      email: data?.email,
+      cause: err instanceof Error ? err.message : String(err),
+    });
   }
 };
 

--- a/src/modules/users/repositories/user.repository.ts
+++ b/src/modules/users/repositories/user.repository.ts
@@ -58,8 +58,15 @@ export const getUser = async (userId: number) => {
   return await prisma.user.findFirstOrThrow({ where: { id: BigInt(userId) } });
 };
 
-// 3. 음식 선호 카테고리 매핑
-// [수정] preferences를 user 테이블에 JSON으로 저장하는 구조로 변경했으므로 현재는 미사용 함수임
+/** preferences에 담긴 food_category_id가 DB에 존재하는지 조회 (이름 해석용) */
+export const findFoodCategoriesByIds = async (ids: number[]) => {
+  if (ids.length === 0) return [];
+  return prisma.foodCategory.findMany({
+    where: { id: { in: ids.map((id) => BigInt(id)) } },
+  });
+};
+
+// 3. 음식 선호 카테고리 매핑 (Junction — 필요 시에만 사용. 회원가입은 user.preferences JSON + 아래 조회로 처리)
 export const setPreference = async (userId: number, foodCategoryId: number): Promise<void> => {
   await prisma.userFoodCategory.create({
     data: {

--- a/src/modules/users/services/user.service.ts
+++ b/src/modules/users/services/user.service.ts
@@ -1,8 +1,11 @@
 import bcrypt from "bcrypt";;
-import { UserSignUpRequest, responseFromUser } from "../dtos/user.dto.js"; //인터페이스 가져오기 
-import { addUser, getUser } from "../repositories/user.repository.js";
+import { UserSignUpRequest, UserSignUpResponse } from "../dtos/user.dto.js"; //인터페이스 가져오기
+import { addUser, getUser, getUserPreferencesByUserId, setPreference } from "../repositories/user.repository.js";
+import { DuplicateUserEmailError } from "../../../common/errors/error.js";
 
-export const userSignUp = async (data: Omit<UserSignUpRequest, "birth_data"> & { birth_data: Date }) => {
+export const userSignUp = async (data: UserSignUpRequest): Promise<UserSignUpResponse> => {
+  const birth_data = new Date(data.birth_data);
+
   // 비밀번호 해싱
   const hashedPassword = await bcrypt.hash(data.password, 10);
   
@@ -11,7 +14,7 @@ export const userSignUp = async (data: Omit<UserSignUpRequest, "birth_data"> & {
     nickname: data.nickname,
     user_phone: data.user_phone,
     user_gender: data.user_gender,
-    birth_data: data.birth_data,    // 문자열을 Date 객체로 변환해서 넘겨줍니다. 
+    birth_data, // 문자열을 Date 객체로 변환해서 넘겨줍니다.
     address: data.address,
     role: data.role,
     point: data.point,
@@ -22,10 +25,16 @@ export const userSignUp = async (data: Omit<UserSignUpRequest, "birth_data"> & {
   });
 
   if (joinUserId === null) {
-    throw new Error("이미 존재하는 이메일입니다.");
+    // 기존 원인 메시지는 유지하면서, 실패한 요청 data도 error.data에 포함
+    throw new DuplicateUserEmailError("이미 존재하는 이메일입니다.", data);
   }
 
-  const user = await getUser(joinUserId);
+  for (const preference of data.preferences) {
+    await setPreference(joinUserId, preference);
+  }
 
-  return responseFromUser({ user });
+  return {
+    userId: joinUserId,
+    preferences: (await getUserPreferencesByUserId(joinUserId)).map((obj) => obj.foodCategory.name),
+  };
 };

--- a/src/modules/users/services/user.service.ts
+++ b/src/modules/users/services/user.service.ts
@@ -1,40 +1,48 @@
-import bcrypt from "bcrypt";;
+import bcrypt from "bcrypt";
 import { UserSignUpRequest, UserSignUpResponse } from "../dtos/user.dto.js"; //인터페이스 가져오기
-import { addUser, getUser, getUserPreferencesByUserId, setPreference } from "../repositories/user.repository.js";
-import { DuplicateUserEmailError } from "../../../common/errors/error.js";
+import { addUser, findFoodCategoriesByIds } from "../repositories/user.repository.js";
+import { DuplicateUserEmailError, ValidationError } from "../../../common/errors/error.js";
 
 export const userSignUp = async (data: UserSignUpRequest): Promise<UserSignUpResponse> => {
   const birth_data = new Date(data.birth_data);
 
+  // 선호 카테고리 ID는 FK(userFoodCategory) 또는 JSON 저장 전에 반드시 존재 여부 확인
+  const categories = await findFoodCategoriesByIds(data.preferences);
+  const foundIds = new Set(categories.map((c) => Number(c.id)));
+  const missingIds = data.preferences.filter((id) => !foundIds.has(id));
+  if (missingIds.length > 0) {
+    throw new ValidationError("존재하지 않는 음식 카테고리 ID가 포함되어 있습니다.", {
+      preferences: data.preferences,
+      invalidIds: missingIds,
+    });
+  }
+
+  const idToName = new Map(categories.map((c) => [Number(c.id), c.name]));
+  const preferenceNames = data.preferences.map((id) => idToName.get(id)!);
+
   // 비밀번호 해싱
   const hashedPassword = await bcrypt.hash(data.password, 10);
-  
+
   const joinUserId = await addUser({
     user_name: data.user_name,
     nickname: data.nickname,
     user_phone: data.user_phone,
     user_gender: data.user_gender,
-    birth_data, // 문자열을 Date 객체로 변환해서 넘겨줍니다.
+    birth_data,
     address: data.address,
     role: data.role,
     point: data.point,
     email: data.email,
     preferences: data.preferences,
     password: hashedPassword,
-    // birth_data: new Date(data.birth_data),    // 문자열을 Date 객체로 변환해서 넘겨줍니다. 이렇게 해도 됨.
   });
 
   if (joinUserId === null) {
-    // 기존 원인 메시지는 유지하면서, 실패한 요청 data도 error.data에 포함
     throw new DuplicateUserEmailError("이미 존재하는 이메일입니다.", data);
-  }
-
-  for (const preference of data.preferences) {
-    await setPreference(joinUserId, preference);
   }
 
   return {
     userId: joinUserId,
-    preferences: (await getUserPreferencesByUserId(joinUserId)).map((obj) => obj.foodCategory.name),
+    preferences: preferenceNames,
   };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,10 @@
     "skipLibCheck": true,         
     "esModuleInterop": true,      
     "forceConsistentCasingInFileNames": true, 
-    "sourceMap": true             
+    "sourceMap": true,
+    
+    /* 데코레이터 문법 사용 여부 */
+    "experimentalDecorators": true,
   },
   "include": ["src/**/*"],        
   "exclude": ["node_modules", "dist"] // 빌드 결과물(dist)도 검사에서 제외하는 게 좋아요!

--- a/tsoa.json
+++ b/tsoa.json
@@ -1,0 +1,14 @@
+{
+    "entryFile": "src/index.ts",
+    "noImplicitAdditionalProperties": "throw-on-extras",
+    "controllerPathGlobs": ["src/**/*.controller.ts"],
+    "spec": {
+      "outputDirectory": "dist",
+      "specVersion": 3
+    },
+    "routes": {
+      "routesDir": "src/generated",
+      "esm": true
+    }
+  }
+  


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
Closes #21 

## 📝 작업 내용
### 1. TSOA 적용
- 모든 도메인(users / shops / reviews / missions) 컨트롤러를 `@Route` / `@Tags` / `@Get` / `@Post` / `@Patch` 기반 클래스로 전환
- `RegisterRoutes(router)`로 일괄 등록 (`/api/v1` prefix)
- `tsoa spec-and-routes` 빌드 스크립트 정리 (`npm start`, `npm run dev`)

### 2. 성공 응답 표준화
- 공통 응답 타입 `ApiResponse<T>` + 헬퍼 `success()` 도입
- 모든 JSON 응답 컨트롤러를 `Promise<ApiResponse<T>>` + `return success(data);` 형태로 통일

```json
{
  "resultType": "SUCCESS",
  "error": null,
  "data": { ... }
}
```

### 3. 에러 처리 통일

- `AppError` 베이스 + 커스텀 에러 클래스 추가
  - `DuplicateUserEmailError` (`U001`, 409)
  - `NotFoundError` (`COMMON404`)
  - `ValidationError` (`COMMON400`)
  - `ConflictError` (`COMMON409`)
  - `InternalServerError` (`COMMON500`)
- 서비스/레포지토리에서 `throw new Error(...)` 제거 → 커스텀 에러로 교체
- 실패한 요청 payload를 `error.data`에 함께 담아 클라이언트/프론트 디버깅 용이성 확보
- 전역 에러 핸들러에서 `AppError` 외 예외(Prisma 등)는 안전한 메시지로 매핑, 원본은 서버 로그에만 출력

```json
{
  "resultType": "FAILED",
  "error": { "errorCode": "...", "message": "...", "data": ... },
  "data": null
}
```

### 4. 회원가입 흐름 개선

- `preferences`의 `food_category_id` 존재 여부를 사전 검증
- 잘못된 ID는 Prisma FK 오류 대신 `ValidationError(COMMON400)`로 명확하게 응답
- 응답의 `preferences`는 카테고리 이름 배열로 매핑

### 5. 공통 미들웨어 등록

- `morgan` (HTTP 요청 로깅), `cookie-parser`, `cors` 등록
- 전역 `res.error()` 헬퍼 미들웨어 추가

## ✅ PR 체크리스트
- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

