### PR TITLE
docs: 탠져린 8주차 미션

### DIFF
--- a/dist/swagger.json
+++ b/dist/swagger.json
@@ -55,6 +55,53 @@
 				"type": "object",
 				"additionalProperties": false
 			},
+			"ApiErrorBody": {
+				"properties": {
+					"errorCode": {
+						"type": "string"
+					},
+					"message": {
+						"type": "string"
+					},
+					"data": {}
+				},
+				"required": [
+					"errorCode",
+					"message",
+					"data"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ApiFailedResponse": {
+				"description": "전역 에러 핸들러(res.error)가 내려주는 실패 응답 형식",
+				"properties": {
+					"resultType": {
+						"type": "string",
+						"enum": [
+							"FAILED"
+						],
+						"nullable": false
+					},
+					"error": {
+						"$ref": "#/components/schemas/ApiErrorBody"
+					},
+					"data": {
+						"type": "number",
+						"enum": [
+							null
+						],
+						"nullable": true
+					}
+				},
+				"required": [
+					"resultType",
+					"error",
+					"data"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
 			"UserSignUpRequest": {
 				"properties": {
 					"user_name": {
@@ -904,11 +951,62 @@
 							"application/json": {
 								"schema": {
 									"$ref": "#/components/schemas/ApiResponse_UserSignUpResponse_"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"email": "user@example.com",
+											"user_name": "홍길동",
+											"nickname": "UMC10th",
+											"user_phone": "01012345678",
+											"user_gender": "여성",
+											"birth_data": "2000-01-01",
+											"address": "서울시",
+											"role": "일반 사용자",
+											"point": 0,
+											"password": "password123",
+											"preferences": [
+												1
+											]
+										}
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "요청 형식 오류 (필수 필드 누락·잘못된 필드명·존재하지 않는 선호 카테고리 ID 등)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"409": {
+						"description": "중복된 이메일 (U001)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "서버 오류 (COMMON500)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
 								}
 							}
 						}
 					}
 				},
+				"description": "회원가입 API",
+				"summary": "회원가입을 처리하는 엔드포인트입니다.",
 				"tags": [
 					"Users"
 				],
@@ -941,6 +1039,8 @@
 						}
 					}
 				},
+				"description": "게스트 페이지 (HTML)",
+				"summary": "로그인 없이 접근 가능한 안내 페이지입니다.",
 				"tags": [
 					"Users"
 				],
@@ -963,6 +1063,8 @@
 						}
 					}
 				},
+				"description": "로그인 안내 페이지 (HTML)",
+				"summary": "인증 실패 시 리다이렉트되는 페이지입니다.",
 				"tags": [
 					"Users"
 				],
@@ -983,8 +1085,20 @@
 								}
 							}
 						}
+					},
+					"401": {
+						"description": "로그인 필요 (미들웨어)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
 					}
 				},
+				"description": "마이페이지 (HTML, 로그인 필요)",
+				"summary": "쿠키 기반 로그인이 필요한 페이지입니다.",
 				"tags": [
 					"Users"
 				],
@@ -1007,6 +1121,8 @@
 						}
 					}
 				},
+				"description": "테스트용 로그인 쿠키 설정 (HTML)",
+				"summary": "개발·테스트용으로 username 쿠키를 설정합니다.",
 				"tags": [
 					"Users"
 				],
@@ -1029,6 +1145,8 @@
 						}
 					}
 				},
+				"description": "테스트용 로그아웃 (HTML)",
+				"summary": "username 쿠키를 삭제합니다.",
 				"tags": [
 					"Users"
 				],
@@ -1046,17 +1164,62 @@
 							"application/json": {
 								"schema": {
 									"$ref": "#/components/schemas/ApiResponse_ShopResponse_"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"owner_id": 1,
+											"region_id": 1,
+											"shop_name": "UMC 맛집",
+											"shop_position": "서울시 강남구",
+											"shop_explain": "UMC 10기 단골 가게",
+											"shop_phone": "0212345678"
+										}
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "요청 형식 오류 (COMMON400)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "존재하지 않는 지역 (COMMON404)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "서버 오류 (COMMON500)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
 								}
 							}
 						}
 					}
 				},
+				"description": "지역 내 가게 등록 API",
+				"summary": "특정 지역에 새 가게를 등록합니다.",
 				"tags": [
 					"Shops"
 				],
 				"security": [],
 				"parameters": [
 					{
+						"description": "가게를 등록할 지역 ID",
 						"in": "path",
 						"name": "regionId",
 						"required": true,
@@ -1088,17 +1251,73 @@
 							"application/json": {
 								"schema": {
 									"$ref": "#/components/schemas/ApiResponse_ReviewCreateResponse_"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"user_id": 1,
+											"user_mission_id": 1,
+											"rating": 4.5,
+											"body": "맛있었어요!",
+											"image_urls": [
+												"https://example.com/review1.jpg"
+											]
+										}
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "요청 형식 오류·별점 범위 오류·미션 미완료 등 (COMMON400)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "존재하지 않는 가게 (COMMON404)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"409": {
+						"description": "해당 미션에 대한 리뷰 중복 (COMMON409)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "서버 오류 (COMMON500)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
 								}
 							}
 						}
 					}
 				},
+				"description": "가게 리뷰 작성 API",
+				"summary": "특정 가게에 리뷰를 등록합니다.",
 				"tags": [
 					"Reviews"
 				],
 				"security": [],
 				"parameters": [
 					{
+						"description": "리뷰를 작성할 가게 ID",
 						"in": "path",
 						"name": "shopId",
 						"required": true,
@@ -1131,14 +1350,47 @@
 								}
 							}
 						}
+					},
+					"400": {
+						"description": "요청 형식 오류 (COMMON400)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "존재하지 않는 가게 (COMMON404)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "서버 오류 (COMMON500)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
 					}
 				},
+				"description": "가게 리뷰 목록 조회 API",
+				"summary": "특정 가게의 리뷰 목록을 커서 기반으로 조회합니다.",
 				"tags": [
 					"Reviews"
 				],
 				"security": [],
 				"parameters": [
 					{
+						"description": "가게 ID",
 						"in": "path",
 						"name": "shopId",
 						"required": true,
@@ -1148,6 +1400,7 @@
 						}
 					},
 					{
+						"description": "페이지네이션 커서 (기본값 0, 이전 응답의 pagination.cursor 사용)",
 						"in": "query",
 						"name": "cursor",
 						"required": false,
@@ -1173,14 +1426,47 @@
 								}
 							}
 						}
+					},
+					"400": {
+						"description": "요청 형식 오류 (COMMON400)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "존재하지 않는 유저 (COMMON404)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "서버 오류 (COMMON500)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
 					}
 				},
+				"description": "내가 작성한 리뷰 목록 조회 API",
+				"summary": "특정 유저가 작성한 리뷰 목록을 커서 기반으로 조회합니다.",
 				"tags": [
 					"Reviews"
 				],
 				"security": [],
 				"parameters": [
 					{
+						"description": "유저 ID",
 						"in": "path",
 						"name": "userId",
 						"required": true,
@@ -1190,6 +1476,7 @@
 						}
 					},
 					{
+						"description": "페이지네이션 커서 (기본값 0)",
 						"in": "query",
 						"name": "cursor",
 						"required": false,
@@ -1212,17 +1499,60 @@
 							"application/json": {
 								"schema": {
 									"$ref": "#/components/schemas/ApiResponse_MissionResponse_"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"shop_id": 1,
+											"title": "리뷰 작성 미션",
+											"body": "리뷰를 작성하면 포인트를 드려요",
+											"point": 100
+										}
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "요청 형식 오류 (COMMON400)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "존재하지 않는 가게 (COMMON404)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "서버 오류 (COMMON500)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
 								}
 							}
 						}
 					}
 				},
+				"description": "가게 미션 등록 API",
+				"summary": "특정 가게에 새 미션을 등록합니다.",
 				"tags": [
 					"Missions"
 				],
 				"security": [],
 				"parameters": [
 					{
+						"description": "미션을 등록할 가게 ID",
 						"in": "path",
 						"name": "shopId",
 						"required": true,
@@ -1255,14 +1585,47 @@
 								}
 							}
 						}
+					},
+					"400": {
+						"description": "요청 형식 오류 (COMMON400)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "존재하지 않는 가게 (COMMON404)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "서버 오류 (COMMON500)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
 					}
 				},
+				"description": "가게 미션 목록 조회 API",
+				"summary": "특정 가게의 미션 목록을 커서 기반으로 조회합니다.",
 				"tags": [
 					"Missions"
 				],
 				"security": [],
 				"parameters": [
 					{
+						"description": "가게 ID",
 						"in": "path",
 						"name": "shopId",
 						"required": true,
@@ -1272,6 +1635,7 @@
 						}
 					},
 					{
+						"description": "페이지네이션 커서 (기본값 0)",
 						"in": "query",
 						"name": "cursor",
 						"required": false,
@@ -1294,11 +1658,61 @@
 							"application/json": {
 								"schema": {
 									"$ref": "#/components/schemas/ApiResponse_UserMissionResponse_"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"user_id": 1,
+											"mission_id": 1
+										}
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "요청 형식 오류 (COMMON400)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "존재하지 않는 미션 (COMMON404)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"409": {
+						"description": "이미 도전 중인 미션 (COMMON409)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "서버 오류 (COMMON500)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
 								}
 							}
 						}
 					}
 				},
+				"description": "미션 도전 API",
+				"summary": "유저가 미션에 도전(진행 중 상태로 등록)합니다.",
 				"tags": [
 					"Missions"
 				],
@@ -1329,14 +1743,47 @@
 								}
 							}
 						}
+					},
+					"400": {
+						"description": "요청 형식 오류 (COMMON400)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "존재하지 않는 유저 (COMMON404)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "서버 오류 (COMMON500)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
 					}
 				},
+				"description": "진행 중인 미션 목록 조회 API",
+				"summary": "유저의 진행 중(IN_PROGRESS) 미션 목록을 커서 기반으로 조회합니다.",
 				"tags": [
 					"Missions"
 				],
 				"security": [],
 				"parameters": [
 					{
+						"description": "유저 ID",
 						"in": "path",
 						"name": "userId",
 						"required": true,
@@ -1346,6 +1793,7 @@
 						}
 					},
 					{
+						"description": "페이지네이션 커서 (기본값 0)",
 						"in": "query",
 						"name": "cursor",
 						"required": false,
@@ -1371,14 +1819,47 @@
 								}
 							}
 						}
+					},
+					"400": {
+						"description": "요청 형식 오류·진행 중이 아닌 미션 (COMMON400)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "존재하지 않는 유저 또는 유저 미션 (COMMON404)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "서버 오류 (COMMON500)",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ApiFailedResponse"
+								}
+							}
+						}
 					}
 				},
+				"description": "진행 중 미션 완료 처리 API",
+				"summary": "유저의 진행 중 미션을 완료(COMPLETED) 상태로 변경합니다.",
 				"tags": [
 					"Missions"
 				],
 				"security": [],
 				"parameters": [
 					{
+						"description": "유저 ID",
 						"in": "path",
 						"name": "userId",
 						"required": true,
@@ -1388,6 +1869,7 @@
 						}
 					},
 					{
+						"description": "유저 미션 ID",
 						"in": "path",
 						"name": "userMissionId",
 						"required": true,
@@ -1402,7 +1884,7 @@
 	},
 	"servers": [
 		{
-			"url": "/"
+			"url": "/api/v1"
 		}
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "express": "^5.2.1",
         "http-status-codes": "^2.3.0",
         "morgan": "^1.10.1",
+        "swagger-ui-express": "^5.0.1",
         "tsoa": "^7.0.0-alpha.0"
       },
       "devDependencies": {
@@ -26,6 +27,7 @@
         "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
+        "@types/swagger-ui-express": "^4.1.8",
         "nodemon": "^3.1.4",
         "prisma": "^7.8.0",
         "tsx": "^4.21.0",
@@ -1222,6 +1224,13 @@
         }
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1824,6 +1833,17 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/accepts": {
@@ -4391,6 +4411,30 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.6.tgz",
+      "integrity": "sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "express": "^5.2.1",
     "http-status-codes": "^2.3.0",
     "morgan": "^1.10.1",
+    "swagger-ui-express": "^5.0.1",
     "tsoa": "^7.0.0-alpha.0"
   },
   "devDependencies": {
@@ -29,6 +30,7 @@
     "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
+    "@types/swagger-ui-express": "^4.1.8",
     "nodemon": "^3.1.4",
     "prisma": "^7.8.0",
     "tsx": "^4.21.0",

--- a/src/common/errors/app.error.ts
+++ b/src/common/errors/app.error.ts
@@ -14,5 +14,4 @@ export class AppError extends Error {
       this.statusCode = params?.statusCode ?? 500;
       this.data = params?.data ?? null;
     }
-  }
-  
+}

--- a/src/common/responses/response.ts
+++ b/src/common/responses/response.ts
@@ -1,10 +1,24 @@
 export interface ApiResponse<T> {
-    resultType: "SUCCESS";
-    error: null;
-    data: T;
-  }
-  export const success = <T>(data: T): ApiResponse<T> => ({
-    resultType: "SUCCESS",
-    error: null,
-    data,
-  });
+  resultType: "SUCCESS";
+  error: null;
+  data: T;
+}
+
+export interface ApiErrorBody {
+  errorCode: string;
+  message: string;
+  data: unknown;
+}
+
+/** 전역 에러 핸들러(res.error)가 내려주는 실패 응답 형식 */
+export interface ApiFailedResponse {
+  resultType: "FAILED";
+  error: ApiErrorBody;
+  data: null;
+}
+
+export const success = <T>(data: T): ApiResponse<T> => ({
+  resultType: "SUCCESS",
+  error: null,
+  data,
+});

--- a/src/generated/routes.ts
+++ b/src/generated/routes.ts
@@ -43,6 +43,26 @@ const models: TsoaRoute.Models = {
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiErrorBody": {
+        "dataType": "refObject",
+        "properties": {
+            "errorCode": {"dataType":"string","required":true},
+            "message": {"dataType":"string","required":true},
+            "data": {"dataType":"any","required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "ApiFailedResponse": {
+        "dataType": "refObject",
+        "properties": {
+            "resultType": {"dataType":"enum","enums":["FAILED"],"required":true},
+            "error": {"ref":"ApiErrorBody","required":true},
+            "data": {"dataType":"enum","enums":[null],"required":true},
+        },
+        "additionalProperties": false,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "UserSignUpRequest": {
         "dataType": "refObject",
         "properties": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,11 @@ import cookieParser from "cookie-parser";
 import morgan from "morgan";
 import { RegisterRoutes } from "./generated/routes.js";
 import { AppError } from "./common/errors/app.error.js";
+// src/index.ts
+import swaggerUi from "swagger-ui-express";
+// ESM 환경에서는 JSON 파일을 가져올 때 아래와 같이 처리합니다.
+import path from "path";
+import fs from "fs";
 
 // 1. 환경 변수 설정
 dotenv.config();
@@ -40,8 +45,27 @@ function isAppError(err: unknown): err is AppError {
   return err instanceof AppError;
 }
 
+function isTsoaValidateError(err: unknown): err is { status: number; fields: Record<string, unknown> } {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "fields" in err &&
+    "status" in err &&
+    (err as { status: number }).status === 400
+  );
+}
+
 /** Prisma 등에서 나온 긴 기술 메시지는 클라이언트에 그대로 노출하지 않음 */
 function clientSafeErrorPayload(err: unknown): { statusCode: number; errorCode: string; message: string; data: unknown } {
+  if (isTsoaValidateError(err)) {
+    return {
+      statusCode: 400,
+      errorCode: "COMMON400",
+      message: "요청 형식이 올바르지 않습니다. 필수 필드·필드명을 확인해 주세요.",
+      data: err.fields,
+    };
+  }
+
   if (isAppError(err)) {
     return {
       statusCode: err.statusCode || 500,
@@ -101,7 +125,12 @@ app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
   });
 });
 
-// 4. 서버 시작
+const swaggerFile = JSON.parse(
+  fs.readFileSync(path.resolve("dist/swagger.json"), "utf8")
+);
+app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerFile));
+
 app.listen(port, () => {
-  console.log(`[server]: Server is running at <http://localhost>:${port}`);
+  console.log(`[server]: Server is running at http://localhost:${port}`);
+  console.log(`[swagger]: http://localhost:${port}/docs`);
 });

--- a/src/modules/missions/controllers/mission.controller.ts
+++ b/src/modules/missions/controllers/mission.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, Get, Patch, Path, Post, Query, Route, Tags } from "tsoa";
-import { ApiResponse, success } from "../../../common/responses/response.js";
+import { Body, Controller, Example, Get, Patch, Path, Post, Query, Response, Route, Tags } from "tsoa";
+import { ApiFailedResponse, ApiResponse, success } from "../../../common/responses/response.js";
 import {
   bodyToMission,
   bodyToUserMission,
@@ -21,7 +21,22 @@ import {
 @Route("shops")
 @Tags("Missions")
 export class ShopMissionController extends Controller {
+  /**
+   * 가게 미션 등록 API
+   * @summary 특정 가게에 새 미션을 등록합니다.
+   * @param shopId 미션을 등록할 가게 ID
+   */
   @Post("{shopId}/missions")
+  @Example<MissionCreateRequest>({
+    shop_id: 1,
+    title: "리뷰 작성 미션",
+    body: "리뷰를 작성하면 포인트를 드려요",
+    point: 100,
+  })
+  @Response<ApiResponse<MissionResponse>>(200, "미션 등록 성공")
+  @Response<ApiFailedResponse>(400, "요청 형식 오류 (COMMON400)")
+  @Response<ApiFailedResponse>(404, "존재하지 않는 가게 (COMMON404)")
+  @Response<ApiFailedResponse>(500, "서버 오류 (COMMON500)")
   public async handleCreateMission(
     @Path() shopId: number,
     @Body() body: MissionCreateRequest,
@@ -31,7 +46,17 @@ export class ShopMissionController extends Controller {
     return success(mission);
   }
 
+  /**
+   * 가게 미션 목록 조회 API
+   * @summary 특정 가게의 미션 목록을 커서 기반으로 조회합니다.
+   * @param shopId 가게 ID
+   * @param cursor 페이지네이션 커서 (기본값 0)
+   */
   @Get("{shopId}/missions")
+  @Response<ApiResponse<MissionsListResponse>>(200, "미션 목록 조회 성공")
+  @Response<ApiFailedResponse>(400, "요청 형식 오류 (COMMON400)")
+  @Response<ApiFailedResponse>(404, "존재하지 않는 가게 (COMMON404)")
+  @Response<ApiFailedResponse>(500, "서버 오류 (COMMON500)")
   public async handleGetMissions(
     @Path() shopId: number,
     @Query() cursor: number = 0,
@@ -44,7 +69,20 @@ export class ShopMissionController extends Controller {
 @Route("missions")
 @Tags("Missions")
 export class MissionController extends Controller {
+  /**
+   * 미션 도전 API
+   * @summary 유저가 미션에 도전(진행 중 상태로 등록)합니다.
+   */
   @Post("challenge")
+  @Example<UserMissionCreateRequest>({
+    user_id: 1,
+    mission_id: 1,
+  })
+  @Response<ApiResponse<UserMissionResponse>>(200, "미션 도전 성공")
+  @Response<ApiFailedResponse>(400, "요청 형식 오류 (COMMON400)")
+  @Response<ApiFailedResponse>(404, "존재하지 않는 미션 (COMMON404)")
+  @Response<ApiFailedResponse>(409, "이미 도전 중인 미션 (COMMON409)")
+  @Response<ApiFailedResponse>(500, "서버 오류 (COMMON500)")
   public async handleChallengeMission(
     @Body() body: UserMissionCreateRequest,
   ): Promise<ApiResponse<UserMissionResponse>> {
@@ -57,7 +95,17 @@ export class MissionController extends Controller {
 @Route("users")
 @Tags("Missions")
 export class UserMissionController extends Controller {
+  /**
+   * 진행 중인 미션 목록 조회 API
+   * @summary 유저의 진행 중(IN_PROGRESS) 미션 목록을 커서 기반으로 조회합니다.
+   * @param userId 유저 ID
+   * @param cursor 페이지네이션 커서 (기본값 0)
+   */
   @Get("{userId}/missions/in-progress")
+  @Response<ApiResponse<InProgressMissionsListResponse>>(200, "진행 중 미션 목록 조회 성공")
+  @Response<ApiFailedResponse>(400, "요청 형식 오류 (COMMON400)")
+  @Response<ApiFailedResponse>(404, "존재하지 않는 유저 (COMMON404)")
+  @Response<ApiFailedResponse>(500, "서버 오류 (COMMON500)")
   public async handleGetInProgressMissions(
     @Path() userId: number,
     @Query() cursor: number = 0,
@@ -66,7 +114,17 @@ export class UserMissionController extends Controller {
     return success(result);
   }
 
+  /**
+   * 진행 중 미션 완료 처리 API
+   * @summary 유저의 진행 중 미션을 완료(COMPLETED) 상태로 변경합니다.
+   * @param userId 유저 ID
+   * @param userMissionId 유저 미션 ID
+   */
   @Patch("{userId}/missions/{userMissionId}/complete")
+  @Response<ApiResponse<UserMissionResponse>>(200, "미션 완료 처리 성공")
+  @Response<ApiFailedResponse>(400, "요청 형식 오류·진행 중이 아닌 미션 (COMMON400)")
+  @Response<ApiFailedResponse>(404, "존재하지 않는 유저 또는 유저 미션 (COMMON404)")
+  @Response<ApiFailedResponse>(500, "서버 오류 (COMMON500)")
   public async handleCompleteInProgressMission(
     @Path() userId: number,
     @Path() userMissionId: number,

--- a/src/modules/reviews/controllers/review.controller.ts
+++ b/src/modules/reviews/controllers/review.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, Get, Path, Post, Query, Route, Tags } from "tsoa";
-import { ApiResponse, success } from "../../../common/responses/response.js";
+import { Body, Controller, Example, Get, Path, Post, Query, Response, Route, Tags } from "tsoa";
+import { ApiFailedResponse, ApiResponse, success } from "../../../common/responses/response.js";
 import {
   bodyToReview,
   MyReviewsListResponse,
@@ -12,7 +12,24 @@ import { createReview, getMyReviews, getReviews } from "../services/review.servi
 @Route("shops")
 @Tags("Reviews")
 export class ReviewController extends Controller {
+  /**
+   * 가게 리뷰 작성 API
+   * @summary 특정 가게에 리뷰를 등록합니다.
+   * @param shopId 리뷰를 작성할 가게 ID
+   */
   @Post("{shopId}/reviews")
+  @Example<ReviewCreateRequest>({
+    user_id: 1,
+    user_mission_id: 1,
+    rating: 4.5,
+    body: "맛있었어요!",
+    image_urls: ["https://example.com/review1.jpg"],
+  })
+  @Response<ApiResponse<ReviewCreateResponse>>(200, "리뷰 작성 성공")
+  @Response<ApiFailedResponse>(400, "요청 형식 오류·별점 범위 오류·미션 미완료 등 (COMMON400)")
+  @Response<ApiFailedResponse>(404, "존재하지 않는 가게 (COMMON404)")
+  @Response<ApiFailedResponse>(409, "해당 미션에 대한 리뷰 중복 (COMMON409)")
+  @Response<ApiFailedResponse>(500, "서버 오류 (COMMON500)")
   public async handleCreateReview(
     @Path() shopId: number,
     @Body() body: ReviewCreateRequest,
@@ -26,7 +43,17 @@ export class ReviewController extends Controller {
     return success(review);
   }
 
+  /**
+   * 가게 리뷰 목록 조회 API
+   * @summary 특정 가게의 리뷰 목록을 커서 기반으로 조회합니다.
+   * @param shopId 가게 ID
+   * @param cursor 페이지네이션 커서 (기본값 0, 이전 응답의 pagination.cursor 사용)
+   */
   @Get("{shopId}/reviews")
+  @Response<ApiResponse<ReviewsListResponse>>(200, "리뷰 목록 조회 성공")
+  @Response<ApiFailedResponse>(400, "요청 형식 오류 (COMMON400)")
+  @Response<ApiFailedResponse>(404, "존재하지 않는 가게 (COMMON404)")
+  @Response<ApiFailedResponse>(500, "서버 오류 (COMMON500)")
   public async handleGetReviews(
     @Path() shopId: number,
     @Query() cursor: number = 0,
@@ -39,7 +66,17 @@ export class ReviewController extends Controller {
 @Route("users")
 @Tags("Reviews")
 export class UserReviewController extends Controller {
+  /**
+   * 내가 작성한 리뷰 목록 조회 API
+   * @summary 특정 유저가 작성한 리뷰 목록을 커서 기반으로 조회합니다.
+   * @param userId 유저 ID
+   * @param cursor 페이지네이션 커서 (기본값 0)
+   */
   @Get("{userId}/reviews")
+  @Response<ApiResponse<MyReviewsListResponse>>(200, "내 리뷰 목록 조회 성공")
+  @Response<ApiFailedResponse>(400, "요청 형식 오류 (COMMON400)")
+  @Response<ApiFailedResponse>(404, "존재하지 않는 유저 (COMMON404)")
+  @Response<ApiFailedResponse>(500, "서버 오류 (COMMON500)")
   public async handleGetMyReviews(
     @Path() userId: number,
     @Query() cursor: number = 0,

--- a/src/modules/shops/controllers/shop.controller.ts
+++ b/src/modules/shops/controllers/shop.controller.ts
@@ -1,12 +1,29 @@
-import { Body, Controller, Path, Post, Route, Tags } from "tsoa";
-import { ApiResponse, success } from "../../../common/responses/response.js";
+import { Body, Controller, Example, Path, Post, Response, Route, Tags } from "tsoa";
+import { ApiFailedResponse, ApiResponse, success } from "../../../common/responses/response.js";
 import { bodyToShop, ShopCreateRequest, ShopResponse } from "../dtos/shop.dto.js";
 import { createShop } from "../services/shop.service.js";
 
 @Route("regions")
 @Tags("Shops")
 export class ShopController extends Controller {
+  /**
+   * 지역 내 가게 등록 API
+   * @summary 특정 지역에 새 가게를 등록합니다.
+   * @param regionId 가게를 등록할 지역 ID
+   */
   @Post("{regionId}/shops")
+  @Example<ShopCreateRequest>({
+    owner_id: 1,
+    region_id: 1,
+    shop_name: "UMC 맛집",
+    shop_position: "서울시 강남구",
+    shop_explain: "UMC 10기 단골 가게",
+    shop_phone: "0212345678",
+  })
+  @Response<ApiResponse<ShopResponse>>(200, "가게 등록 성공")
+  @Response<ApiFailedResponse>(400, "요청 형식 오류 (COMMON400)")
+  @Response<ApiFailedResponse>(404, "존재하지 않는 지역 (COMMON404)")
+  @Response<ApiFailedResponse>(500, "서버 오류 (COMMON500)")
   public async handleCreateShop(
     @Path() regionId: number,
     @Body() body: ShopCreateRequest,

--- a/src/modules/users/controllers/user.controller.ts
+++ b/src/modules/users/controllers/user.controller.ts
@@ -1,24 +1,47 @@
-import { Body, Controller, Get, Middlewares, Post, Request, Route, Tags } from "tsoa";
+import { Body, Controller, Example, Get, Middlewares, Post, Request, Response, Route, Tags } from "tsoa";
 import { Request as ExpressRequest, Response as ExpressResponse, NextFunction } from "express";
 import { StatusCodes } from "http-status-codes";
 import { UserSignUpRequest, UserSignUpResponse } from "../dtos/user.dto.js";
 import { userSignUp } from "../services/user.service.js";
 import { authorizeUser } from "../../../common/middlewares/auth.middleware.js";
-import { ApiResponse, success } from "../../../common/responses/response.js";
+import { ApiFailedResponse, ApiResponse, success } from "../../../common/responses/response.js";
 
 @Route("users")
 @Tags("Users")
 export class UserController extends Controller {
+  /**
+   * 회원가입 API
+   * @summary 회원가입을 처리하는 엔드포인트입니다.
+   */
   @Post("signup")
+  @Example<UserSignUpRequest>({
+    email: "user@example.com",
+    user_name: "홍길동",
+    nickname: "UMC10th",
+    user_phone: "01012345678",
+    user_gender: "여성",
+    birth_data: "2000-01-01",
+    address: "서울시",
+    role: "일반 사용자",
+    point: 0,
+    password: "password123",
+    preferences: [1],
+  })
+  @Response<ApiResponse<UserSignUpResponse>>(200, "회원가입 성공")
+  @Response<ApiFailedResponse>(400, "요청 형식 오류 (필수 필드 누락·잘못된 필드명·존재하지 않는 선호 카테고리 ID 등)")
+  @Response<ApiFailedResponse>(409, "중복된 이메일 (U001)")
+  @Response<ApiFailedResponse>(500, "서버 오류 (COMMON500)")
   public async handleUserSignUp(@Body() body: UserSignUpRequest): Promise<ApiResponse<UserSignUpResponse>> {
-    console.log("회원가입을 요청했습니다!");
-    console.log("body:", body);
-
     const user = await userSignUp(body);
     return success(user);
   }
 
+  /**
+   * 게스트 페이지 (HTML)
+   * @summary 로그인 없이 접근 가능한 안내 페이지입니다.
+   */
   @Get("guest")
+  @Response<string>(200, "HTML 페이지")
   public async handleGuestPage(): Promise<string> {
     return `
       <h1>게스트 페이지</h1>
@@ -29,13 +52,24 @@ export class UserController extends Controller {
     `;
   }
 
+  /**
+   * 로그인 안내 페이지 (HTML)
+   * @summary 인증 실패 시 리다이렉트되는 페이지입니다.
+   */
   @Get("login")
+  @Response<string>(200, "HTML 페이지")
   public async handleLoginPage(): Promise<string> {
     return "<h1>로그인 페이지</h1><p>로그인이 필요한 페이지에서 튕겨나오면 여기로 옵니다.</p>";
   }
 
+  /**
+   * 마이페이지 (HTML, 로그인 필요)
+   * @summary 쿠키 기반 로그인이 필요한 페이지입니다.
+   */
   @Get("mypage")
   @Middlewares(authorizeUser())
+  @Response<string>(200, "HTML 페이지")
+  @Response<ApiFailedResponse>(401, "로그인 필요 (미들웨어)")
   public async handleMypage(@Request() req: ExpressRequest): Promise<string> {
     return `
       <h1>마이페이지</h1>
@@ -44,13 +78,23 @@ export class UserController extends Controller {
     `;
   }
 
+  /**
+   * 테스트용 로그인 쿠키 설정 (HTML)
+   * @summary 개발·테스트용으로 username 쿠키를 설정합니다.
+   */
   @Get("set-login")
+  @Response<string>(200, "HTML 안내 문구")
   public async handleSetLogin(@Request() req: ExpressRequest): Promise<string> {
     req.res!.cookie("username", "UMC10th", { maxAge: 3600000 });
     return '로그인 쿠키(username=UMC10th) 생성 완료! <a href="/api/users/mypage">마이페이지로 이동</a>';
   }
 
+  /**
+   * 테스트용 로그아웃 (HTML)
+   * @summary username 쿠키를 삭제합니다.
+   */
   @Get("set-logout")
+  @Response<string>(200, "HTML 안내 문구")
   public async handleSetLogout(@Request() req: ExpressRequest): Promise<string> {
     req.res!.clearCookie("username");
     return '로그아웃 완료 (쿠키 삭제). <a href="/api/users/guest">메인으로</a>';

--- a/tsoa.json
+++ b/tsoa.json
@@ -4,7 +4,8 @@
     "controllerPathGlobs": ["src/**/*.controller.ts"],
     "spec": {
       "outputDirectory": "dist",
-      "specVersion": 3
+      "specVersion": 3,
+      "basePath": "/api/v1"
     },
     "routes": {
       "routesDir": "src/generated",


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)
> Closes #25 

## 📝 작업 내용

- 기존 Users / Shops / Reviews / Missions API에 TSOA 데코레이터와 JSDoc 주석을 추가해 Swagger 문서화
- 공통 응답 타입(`ApiResponse`, `ApiFailedResponse`)을 정의하고 각 엔드포인트의 성공/실패 응답 스키마를 설정
- `swagger-ui-express`와 `tsoa` 설정을 통해 `/docs`에서 Swagger UI로 API 스펙 확인 가능하도록 구성

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

